### PR TITLE
fix(plx): enforce single-task execution and add command reference

### DIFF
--- a/.claude/commands/plx/get-task.md
+++ b/.claude/commands/plx/get-task.md
@@ -13,8 +13,6 @@ tags: [plx, task, workflow]
 **Steps**
 1. Run `openspec get task` to get the highest-priority task (auto-transitions to in-progress).
 2. Execute the task following its Implementation Checklist.
-3. Mark checklist items complete as you finish them.
-4. When done, either:
-   - Run `openspec complete task --id <task-id>` to mark done explicitly, OR
-   - Run `openspec get task` to auto-complete (if all items checked) and get next task.
+3. When all checklist items are complete, run `openspec complete task --id <task-id>` to mark the task as done.
+4. **Stop and await user confirmation** before proceeding to the next task.
 <!-- OPENSPEC:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,90 @@ Use `@/openspec/AGENTS.md` to learn:
 - Spec format and conventions
 - Project structure and guidelines
 
+## Commands
+
+### Project Setup
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx init [path]` | Initialize OpenSpec | New project setup |
+| `plx init --tools <list>` | Initialize with specific AI tools | Non-interactive setup |
+| `plx update [path]` | Refresh instruction files | After CLI updates |
+
+### Navigation & Listing
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx list` | List active changes | Check what's in progress |
+| `plx list --specs` | List specifications | Find existing specs |
+| `plx view` | Interactive dashboard | Visual overview |
+
+### Task Management
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx get task` | Get next prioritized task | Start work |
+| `plx get task --id <id>` | Get specific task | Resume specific task |
+| `plx get task --did-complete-previous` | Complete current, get next | Advance workflow |
+| `plx get task --constraints` | Show only Constraints | Focus on constraints |
+| `plx get task --acceptance-criteria` | Show only AC | Focus on acceptance |
+| `plx get tasks` | List all open tasks | See all pending work |
+| `plx get tasks --id <change-id>` | List tasks for change | See tasks in a change |
+| `plx complete task --id <id>` | Mark task done | Finish a task |
+| `plx complete change --id <id>` | Complete all tasks | Finish entire change |
+| `plx undo task --id <id>` | Revert task to to-do | Reopen a task |
+| `plx undo change --id <id>` | Revert all tasks | Reopen entire change |
+
+### Item Retrieval
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx get change --id <id>` | Get change by ID | View specific change |
+| `plx get spec --id <id>` | Get spec by ID | View specific spec |
+
+### Display & Inspection
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx show <item>` | Display change or spec | View details |
+| `plx show <item> --json` | JSON output | Machine-readable |
+| `plx show <item> --type change\|spec` | Disambiguate item type | When names collide |
+| `plx show <change> --deltas-only` | Show only deltas | Focus on changes |
+
+### Validation
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx validate <item>` | Validate single item | Check for issues |
+| `plx validate --all` | Validate everything | Full project check |
+| `plx validate --changes` | Validate all changes | Check all changes |
+| `plx validate --specs` | Validate all specs | Check all specs |
+| `plx validate --strict` | Strict validation | Comprehensive check |
+| `plx validate --json` | JSON output | Machine-readable |
+
+### Archival
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx archive <change-id>` | Archive completed change | After deployment |
+| `plx archive <id> --yes` | Archive without prompts | Non-interactive |
+| `plx archive <id> --skip-specs` | Archive, skip spec updates | Tooling-only changes |
+
+### Configuration
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx config path` | Show config file location | Find config |
+| `plx config list` | Show all settings | View configuration |
+| `plx config get <key>` | Get specific value | Read a setting |
+| `plx config set <key> <value>` | Set a value | Modify configuration |
+
+### Shell Completions
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx completion install [shell]` | Install completions | Enable tab completion |
+| `plx completion uninstall [shell]` | Remove completions | Remove tab completion |
+| `plx completion generate [shell]` | Generate script | Manual setup |
+
+### Global Flags
+| Flag | Description |
+|------|-------------|
+| `--json` | Machine-readable JSON output |
+| `--no-interactive` | Disable prompts |
+| `--no-color` | Disable color output |
+
 Keep this managed block so 'openspec update' can refresh the instructions.
 
 <!-- OPENSPEC:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,90 @@ Use `@/openspec/AGENTS.md` to learn:
 - Spec format and conventions
 - Project structure and guidelines
 
+## Commands
+
+### Project Setup
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx init [path]` | Initialize OpenSpec | New project setup |
+| `plx init --tools <list>` | Initialize with specific AI tools | Non-interactive setup |
+| `plx update [path]` | Refresh instruction files | After CLI updates |
+
+### Navigation & Listing
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx list` | List active changes | Check what's in progress |
+| `plx list --specs` | List specifications | Find existing specs |
+| `plx view` | Interactive dashboard | Visual overview |
+
+### Task Management
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx get task` | Get next prioritized task | Start work |
+| `plx get task --id <id>` | Get specific task | Resume specific task |
+| `plx get task --did-complete-previous` | Complete current, get next | Advance workflow |
+| `plx get task --constraints` | Show only Constraints | Focus on constraints |
+| `plx get task --acceptance-criteria` | Show only AC | Focus on acceptance |
+| `plx get tasks` | List all open tasks | See all pending work |
+| `plx get tasks --id <change-id>` | List tasks for change | See tasks in a change |
+| `plx complete task --id <id>` | Mark task done | Finish a task |
+| `plx complete change --id <id>` | Complete all tasks | Finish entire change |
+| `plx undo task --id <id>` | Revert task to to-do | Reopen a task |
+| `plx undo change --id <id>` | Revert all tasks | Reopen entire change |
+
+### Item Retrieval
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx get change --id <id>` | Get change by ID | View specific change |
+| `plx get spec --id <id>` | Get spec by ID | View specific spec |
+
+### Display & Inspection
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx show <item>` | Display change or spec | View details |
+| `plx show <item> --json` | JSON output | Machine-readable |
+| `plx show <item> --type change\|spec` | Disambiguate item type | When names collide |
+| `plx show <change> --deltas-only` | Show only deltas | Focus on changes |
+
+### Validation
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx validate <item>` | Validate single item | Check for issues |
+| `plx validate --all` | Validate everything | Full project check |
+| `plx validate --changes` | Validate all changes | Check all changes |
+| `plx validate --specs` | Validate all specs | Check all specs |
+| `plx validate --strict` | Strict validation | Comprehensive check |
+| `plx validate --json` | JSON output | Machine-readable |
+
+### Archival
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx archive <change-id>` | Archive completed change | After deployment |
+| `plx archive <id> --yes` | Archive without prompts | Non-interactive |
+| `plx archive <id> --skip-specs` | Archive, skip spec updates | Tooling-only changes |
+
+### Configuration
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx config path` | Show config file location | Find config |
+| `plx config list` | Show all settings | View configuration |
+| `plx config get <key>` | Get specific value | Read a setting |
+| `plx config set <key> <value>` | Set a value | Modify configuration |
+
+### Shell Completions
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| `plx completion install [shell]` | Install completions | Enable tab completion |
+| `plx completion uninstall [shell]` | Remove completions | Remove tab completion |
+| `plx completion generate [shell]` | Generate script | Manual setup |
+
+### Global Flags
+| Flag | Description |
+|------|-------------|
+| `--json` | Machine-readable JSON output |
+| `--no-interactive` | Disable prompts |
+| `--no-color` | Disable color output |
+
 Keep this managed block so 'openspec update' can refresh the instructions.
 
 <!-- OPENSPEC:END -->

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -51,9 +51,9 @@ Track these steps as TODOs and complete them one by one.
 1. **Read proposal.md** - Understand what's being built
 2. **Read design.md** (if exists) - Review technical decisions
 3. **Get next task** - Run `openspec get task` to retrieve the next task (auto-transitions to in-progress)
-4. **Implement task** - Work through the Implementation Checklist, marking items as you complete them
-5. **Complete task** - Run `openspec get task` (auto-completes if all items checked) or `openspec complete task --id <id>`
-6. **Repeat** - Continue until all tasks are done
+4. **Implement task** - Work through the Implementation Checklist
+5. **Complete task** - Run `openspec complete task --id <id>` to mark the task as done
+6. **Stop and await user confirmation** - Do not proceed to the next task until the user requests it
 7. **Approval gate** - Do not start implementation until the proposal is reviewed and approved
 
 ### Stage 3: Archiving Changes

--- a/openspec/changes/fix-single-task-execution/proposal.md
+++ b/openspec/changes/fix-single-task-execution/proposal.md
@@ -1,0 +1,23 @@
+---
+tracked-issues:
+  - tracker: linear
+    id: PLX-26
+    url: https://linear.app/de-app-specialist/issue/PLX-26
+---
+
+# Change: Fix single task execution
+
+## Why
+
+When running `plx get task`, agents execute multiple tasks instead of stopping after completing one task. The current template instructions tell agents to "Repeat - Continue until all tasks are done" and imply automatic continuation to the next task, which violates user expectations of single-task-per-request behavior.
+
+## What Changes
+
+- Update `plx-slash-command-templates.ts` to add explicit "Stop and await user confirmation" step
+- Update `agents-template.ts` Stage 2 workflow to replace "Repeat" instruction with stop-and-wait behavior
+- Regenerate slash command files via `openspec update`
+
+## Impact
+
+- Affected specs: `docs-agent-instructions`, `plx-slash-commands`
+- Affected code: `src/core/templates/plx-slash-command-templates.ts`, `src/core/templates/agents-template.ts`

--- a/openspec/changes/fix-single-task-execution/specs/docs-agent-instructions/spec.md
+++ b/openspec/changes/fix-single-task-execution/specs/docs-agent-instructions/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Single Task Execution
+
+`openspec/AGENTS.md` SHALL instruct agents to stop after completing one task and await user confirmation before proceeding to the next task.
+
+#### Scenario: Documenting stop-and-wait behavior
+
+- **WHEN** an agent reads Stage 2: Implementing Changes
+- **THEN** find instruction to stop after completing the current task
+- **AND** find instruction to await user confirmation before proceeding to the next task
+- **AND** NOT find instruction to automatically repeat or continue until all tasks are done

--- a/openspec/changes/fix-single-task-execution/specs/plx-slash-commands/spec.md
+++ b/openspec/changes/fix-single-task-execution/specs/plx-slash-commands/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Get Task Stop Behavior
+
+The `plx/get-task` slash command SHALL instruct agents to stop after completing the retrieved task and await user confirmation before proceeding.
+
+#### Scenario: Get-task command includes stop instruction
+
+- **WHEN** the `plx/get-task` slash command is generated
+- **THEN** include a step instructing agents to stop after task completion
+- **AND** include instruction to await user confirmation before proceeding to the next task
+- **AND** NOT include instruction to automatically get the next task after completion

--- a/openspec/changes/fix-single-task-execution/tasks/001-update-templates.md
+++ b/openspec/changes/fix-single-task-execution/tasks/001-update-templates.md
@@ -1,0 +1,42 @@
+---
+status: done
+---
+
+# Task: Update template instructions
+
+## End Goal
+
+Template instructions explicitly tell agents to stop after completing one task and await user confirmation before proceeding.
+
+## Currently
+
+- `plx-slash-command-templates.ts` Step 4 says "get next task" implying automatic continuation
+- `agents-template.ts` Stage 2, Step 6 says "Repeat - Continue until all tasks are done"
+
+## Should
+
+- Both templates include explicit "Stop and await user confirmation" instruction
+- No implication of automatic continuation to subsequent tasks
+
+## Constraints
+
+- [ ] Changes must not break existing CLI functionality
+- [ ] Template changes must maintain consistent messaging between AGENTS.md and slash commands
+
+## Acceptance Criteria
+
+- [ ] `getTaskSteps` in `plx-slash-command-templates.ts` includes explicit stop instruction
+- [ ] Stage 2 in `agents-template.ts` replaces "Repeat" with stop-and-wait instruction
+- [ ] TypeScript compiles without errors
+
+## Implementation Checklist
+
+- [x] 1.1 Update `getTaskSteps` in `src/core/templates/plx-slash-command-templates.ts` to replace step 4 with explicit completion and stop instructions
+- [x] 1.2 Update Stage 2 in `src/core/templates/agents-template.ts` to replace step 6 "Repeat" with "Stop and await user confirmation"
+- [x] 1.3 Run `npm run build` to verify TypeScript compiles
+
+## Notes
+
+The change affects two template constants:
+- `getTaskSteps` in `plx-slash-command-templates.ts` (lines 29-35)
+- Stage 2 workflow in `agents-template.ts` (lines 49-57)

--- a/openspec/changes/fix-single-task-execution/tasks/002-regenerate-commands.md
+++ b/openspec/changes/fix-single-task-execution/tasks/002-regenerate-commands.md
@@ -1,0 +1,36 @@
+---
+status: done
+---
+
+# Task: Regenerate slash commands
+
+## End Goal
+
+Generated slash command files reflect the updated template instructions with explicit stop-and-wait behavior.
+
+## Currently
+
+`.claude/commands/plx/get-task.md` contains instructions that imply automatic continuation to the next task.
+
+## Should
+
+`.claude/commands/plx/get-task.md` contains explicit "Stop and await user confirmation" instruction.
+
+## Constraints
+
+- [ ] Regeneration must use `openspec update` command
+- [ ] Generated content must be within OpenSpec markers
+
+## Acceptance Criteria
+
+- [ ] `.claude/commands/plx/get-task.md` contains "Stop and await user confirmation" step
+- [ ] No reference to "get next task" or automatic continuation remains
+
+## Implementation Checklist
+
+- [x] 2.1 Run `npx openspec update` to regenerate slash command files
+- [x] 2.2 Verify `.claude/commands/plx/get-task.md` contains updated instructions
+
+## Notes
+
+The `openspec update` command regenerates content within `<!-- OPENSPEC:START -->` and `<!-- OPENSPEC:END -->` markers.

--- a/openspec/changes/fix-single-task-execution/tasks/003-verify-changes.md
+++ b/openspec/changes/fix-single-task-execution/tasks/003-verify-changes.md
@@ -1,0 +1,39 @@
+---
+status: done
+---
+
+# Task: Verify changes
+
+## End Goal
+
+All changes are complete, consistent, and ready for deployment.
+
+## Currently
+
+Template changes and regeneration have been applied but not verified for consistency.
+
+## Should
+
+All generated files match the updated template content and pass validation.
+
+## Constraints
+
+- [ ] Must verify all affected files are updated
+- [ ] Must ensure no conflicting instructions remain
+
+## Acceptance Criteria
+
+- [ ] `openspec/AGENTS.md` contains updated Stage 2 instructions
+- [ ] `.claude/commands/plx/get-task.md` contains updated steps
+- [ ] No references to "Repeat" or "continue until all tasks are done" remain in agent-facing instructions
+- [ ] Instructions in AGENTS.md and get-task.md are consistent
+
+## Implementation Checklist
+
+- [x] 3.1 Read `openspec/AGENTS.md` and verify Stage 2 contains stop-and-wait instruction
+- [x] 3.2 Read `.claude/commands/plx/get-task.md` and verify steps include stop-and-wait
+- [x] 3.3 Search for any remaining "Repeat" or continuation instructions in generated files
+
+## Notes
+
+This task ensures consistency between the two primary agent instruction sources.

--- a/src/core/templates/agents-root-stub.ts
+++ b/src/core/templates/agents-root-stub.ts
@@ -12,5 +12,89 @@ Use \`@/openspec/AGENTS.md\` to learn:
 - Spec format and conventions
 - Project structure and guidelines
 
+## Commands
+
+### Project Setup
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx init [path]\` | Initialize OpenSpec | New project setup |
+| \`plx init --tools <list>\` | Initialize with specific AI tools | Non-interactive setup |
+| \`plx update [path]\` | Refresh instruction files | After CLI updates |
+
+### Navigation & Listing
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx list\` | List active changes | Check what's in progress |
+| \`plx list --specs\` | List specifications | Find existing specs |
+| \`plx view\` | Interactive dashboard | Visual overview |
+
+### Task Management
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx get task\` | Get next prioritized task | Start work |
+| \`plx get task --id <id>\` | Get specific task | Resume specific task |
+| \`plx get task --did-complete-previous\` | Complete current, get next | Advance workflow |
+| \`plx get task --constraints\` | Show only Constraints | Focus on constraints |
+| \`plx get task --acceptance-criteria\` | Show only AC | Focus on acceptance |
+| \`plx get tasks\` | List all open tasks | See all pending work |
+| \`plx get tasks --id <change-id>\` | List tasks for change | See tasks in a change |
+| \`plx complete task --id <id>\` | Mark task done | Finish a task |
+| \`plx complete change --id <id>\` | Complete all tasks | Finish entire change |
+| \`plx undo task --id <id>\` | Revert task to to-do | Reopen a task |
+| \`plx undo change --id <id>\` | Revert all tasks | Reopen entire change |
+
+### Item Retrieval
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx get change --id <id>\` | Get change by ID | View specific change |
+| \`plx get spec --id <id>\` | Get spec by ID | View specific spec |
+
+### Display & Inspection
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx show <item>\` | Display change or spec | View details |
+| \`plx show <item> --json\` | JSON output | Machine-readable |
+| \`plx show <item> --type change\\|spec\` | Disambiguate item type | When names collide |
+| \`plx show <change> --deltas-only\` | Show only deltas | Focus on changes |
+
+### Validation
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx validate <item>\` | Validate single item | Check for issues |
+| \`plx validate --all\` | Validate everything | Full project check |
+| \`plx validate --changes\` | Validate all changes | Check all changes |
+| \`plx validate --specs\` | Validate all specs | Check all specs |
+| \`plx validate --strict\` | Strict validation | Comprehensive check |
+| \`plx validate --json\` | JSON output | Machine-readable |
+
+### Archival
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx archive <change-id>\` | Archive completed change | After deployment |
+| \`plx archive <id> --yes\` | Archive without prompts | Non-interactive |
+| \`plx archive <id> --skip-specs\` | Archive, skip spec updates | Tooling-only changes |
+
+### Configuration
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx config path\` | Show config file location | Find config |
+| \`plx config list\` | Show all settings | View configuration |
+| \`plx config get <key>\` | Get specific value | Read a setting |
+| \`plx config set <key> <value>\` | Set a value | Modify configuration |
+
+### Shell Completions
+| Command | Description | When to Use |
+|---------|-------------|-------------|
+| \`plx completion install [shell]\` | Install completions | Enable tab completion |
+| \`plx completion uninstall [shell]\` | Remove completions | Remove tab completion |
+| \`plx completion generate [shell]\` | Generate script | Manual setup |
+
+### Global Flags
+| Flag | Description |
+|------|-------------|
+| \`--json\` | Machine-readable JSON output |
+| \`--no-interactive\` | Disable prompts |
+| \`--no-color\` | Disable color output |
+
 Keep this managed block so 'openspec update' can refresh the instructions.
 `;

--- a/src/core/templates/agents-template.ts
+++ b/src/core/templates/agents-template.ts
@@ -51,9 +51,9 @@ Track these steps as TODOs and complete them one by one.
 1. **Read proposal.md** - Understand what's being built
 2. **Read design.md** (if exists) - Review technical decisions
 3. **Get next task** - Run \`openspec get task\` to retrieve the next task (auto-transitions to in-progress)
-4. **Implement task** - Work through the Implementation Checklist, marking items as you complete them
-5. **Complete task** - Run \`openspec get task\` (auto-completes if all items checked) or \`openspec complete task --id <id>\`
-6. **Repeat** - Continue until all tasks are done
+4. **Implement task** - Work through the Implementation Checklist
+5. **Complete task** - Run \`openspec complete task --id <id>\` to mark the task as done
+6. **Stop and await user confirmation** - Do not proceed to the next task until the user requests it
 7. **Approval gate** - Do not start implementation until the proposal is reviewed and approved
 
 ### Stage 3: Archiving Changes

--- a/src/core/templates/plx-slash-command-templates.ts
+++ b/src/core/templates/plx-slash-command-templates.ts
@@ -29,10 +29,8 @@ const getTaskGuardrails = `**Guardrails**
 const getTaskSteps = `**Steps**
 1. Run \`openspec get task\` to get the highest-priority task (auto-transitions to in-progress).
 2. Execute the task following its Implementation Checklist.
-3. Mark checklist items complete as you finish them.
-4. When done, either:
-   - Run \`openspec complete task --id <task-id>\` to mark done explicitly, OR
-   - Run \`openspec get task\` to auto-complete (if all items checked) and get next task.`;
+3. When all checklist items are complete, run \`openspec complete task --id <task-id>\` to mark the task as done.
+4. **Stop and await user confirmation** before proceeding to the next task.`;
 
 const compactGuardrails = `**Guardrails**
 - Save ALL modified files before creating PROGRESS.md.

--- a/src/services/item-retrieval.ts
+++ b/src/services/item-retrieval.ts
@@ -11,6 +11,7 @@ import {
   TaskFileInfo,
   TASKS_DIRECTORY_NAME,
 } from '../utils/task-progress.js';
+import { getTaskIdFromFilename } from './task-id.js';
 
 export interface TaskWithContext {
   task: TaskFileInfo;
@@ -226,7 +227,7 @@ export class ItemRetrievalService {
               };
 
               openTasks.push({
-                taskId: `${changeId}/${parsed.name}`,
+                taskId: getTaskIdFromFilename(filename),
                 changeId,
                 task,
                 status,

--- a/src/services/task-id.ts
+++ b/src/services/task-id.ts
@@ -1,0 +1,62 @@
+/**
+ * Service for consistent task ID management.
+ *
+ * Canonical task ID format: `NNN-kebab-name` (e.g., `001-update-templates`)
+ * - Always includes the 3-digit sequence prefix
+ * - Never includes the .md extension
+ */
+
+import { TASK_FILE_PREFIX_PATTERN, parseTaskFilename } from '../utils/task-file-parser.js';
+
+export interface ParsedTaskId {
+  sequence: number;
+  name: string;
+}
+
+/**
+ * Gets the canonical task ID from a task object.
+ * @param task Object with filename property (e.g., TaskFileInfo)
+ * @returns Canonical task ID (e.g., "001-update-templates")
+ */
+export function getTaskId(task: { filename: string }): string {
+  return getTaskIdFromFilename(task.filename);
+}
+
+/**
+ * Gets the canonical task ID from a filename.
+ * @param filename The task filename (e.g., "001-update-templates.md")
+ * @returns Canonical task ID (e.g., "001-update-templates")
+ */
+export function getTaskIdFromFilename(filename: string): string {
+  return filename.replace(/\.md$/, '');
+}
+
+/**
+ * Parses a task ID into its components.
+ * @param taskId The task ID (e.g., "001-update-templates")
+ * @returns Parsed components or null if invalid format
+ */
+export function parseTaskId(taskId: string): ParsedTaskId | null {
+  // Add .md extension if needed for pattern matching
+  const filename = taskId.endsWith('.md') ? taskId : `${taskId}.md`;
+  return parseTaskFilename(filename);
+}
+
+/**
+ * Normalizes a task ID to canonical format.
+ * @param taskId Input task ID (may or may not have .md extension)
+ * @returns Canonical task ID without .md extension
+ */
+export function normalizeTaskId(taskId: string): string {
+  return taskId.replace(/\.md$/, '');
+}
+
+/**
+ * Validates that a string is a valid task ID format.
+ * @param taskId The string to validate
+ * @returns True if valid task ID format
+ */
+export function isValidTaskId(taskId: string): boolean {
+  const filename = taskId.endsWith('.md') ? taskId : `${taskId}.md`;
+  return TASK_FILE_PREFIX_PATTERN.test(filename);
+}

--- a/test/commands/complete.test.ts
+++ b/test/commands/complete.test.ts
@@ -286,7 +286,7 @@ status: to-do
       const json = JSON.parse(output);
 
       expect(json.completedTasks).toHaveLength(1);
-      expect(json.skippedTasks).toContain('done');
+      expect(json.skippedTasks).toContain('001-done');
     } finally {
       process.chdir(originalCwd);
     }

--- a/test/commands/get.test.ts
+++ b/test/commands/get.test.ts
@@ -66,7 +66,7 @@ status: to-do
         expect(output).toContain('Proposal: test-change');
         expect(output).toContain('Design');
         expect(output).toContain('Test design content');
-        expect(output).toContain('Task 1: first-task');
+        expect(output).toContain('Task 1: 001-first-task');
         expect(output).toContain('Do something');
       } finally {
         process.chdir(originalCwd);
@@ -142,7 +142,7 @@ status: in-progress
         expect(json.task).toBeDefined();
         expect(json.task.filename).toBe('001-first-task.md');
         expect(json.task.sequence).toBe(1);
-        expect(json.task.name).toBe('first-task');
+        expect(json.task.id).toBe('001-first-task');
         expect(json.task.status).toBe('in-progress');
         expect(json.taskContent).toContain('First Task');
         expect(json.changeDocuments).toBeDefined();
@@ -211,7 +211,7 @@ status: to-do
         );
 
         // Should show second task
-        expect(output).toContain('Task 2: second-task');
+        expect(output).toContain('Task 2: 002-second-task');
         expect(output).toContain('Do something else');
 
         // Should NOT show proposal (only task with --did-complete-previous)
@@ -265,7 +265,7 @@ status: to-do
           { encoding: 'utf-8' }
         );
         expect(output).toContain('No in-progress task found');
-        expect(output).toContain('Task 1: first-task');
+        expect(output).toContain('Task 1: 001-first-task');
 
         // Verify task is now in-progress
         const taskContent = await fs.readFile(
@@ -391,7 +391,7 @@ status: to-do
         const json = JSON.parse(output);
 
         expect(json.completedTask).toBeDefined();
-        expect(json.completedTask.name).toBe('first-task');
+        expect(json.completedTask.id).toBe('001-first-task');
         expect(json.completedTask.completedItems).toContain('First item');
         expect(json.completedTask.completedItems).toContain('Second item');
       } finally {
@@ -441,7 +441,7 @@ status: to-do
           { encoding: 'utf-8' }
         );
 
-        expect(output).toContain('Completed task: first-task');
+        expect(output).toContain('Completed task: 001-first-task');
         expect(output).toContain('Marked complete:');
         expect(output).toContain('First item');
       } finally {
@@ -498,10 +498,10 @@ status: to-do
         });
 
         // Should show auto-completed message
-        expect(output).toContain('Auto-completed task: first-task');
+        expect(output).toContain('Auto-completed task: 001-first-task');
 
         // Should show second task
-        expect(output).toContain('Task 2: second-task');
+        expect(output).toContain('Task 2: 002-second-task');
         expect(output).toContain('Second item');
 
         // Should NOT show proposal/design (change documents excluded after auto-complete)
@@ -556,7 +556,7 @@ status: in-progress
         });
 
         // Should show the in-progress task (not auto-completed)
-        expect(output).toContain('Task 1: first-task');
+        expect(output).toContain('Task 1: 001-first-task');
         expect(output).toContain('Not done item');
 
         // Should NOT show auto-completed message
@@ -620,7 +620,7 @@ status: to-do
         });
 
         // Should show the in-progress task (first-task has no checkboxes, so not auto-completed)
-        expect(output).toContain('Task 1: first-task');
+        expect(output).toContain('Task 1: 001-first-task');
 
         // Should NOT show auto-completed message
         expect(output).not.toContain('Auto-completed');
@@ -693,10 +693,10 @@ status: to-do
         });
 
         // Should show auto-completed message
-        expect(output).toContain('Auto-completed task: second-task');
+        expect(output).toContain('Auto-completed task: 002-second-task');
 
         // Should show third task (the next task after auto-completion)
-        expect(output).toContain('Task 3: third-task');
+        expect(output).toContain('Task 3: 003-third-task');
 
         // Verify second task is now done
         const secondTaskContent = await fs.readFile(
@@ -760,11 +760,11 @@ status: to-do
 
         // Should include autoCompletedTask
         expect(json.autoCompletedTask).toBeDefined();
-        expect(json.autoCompletedTask.name).toBe('first-task');
+        expect(json.autoCompletedTask.id).toBe('001-first-task');
 
         // Should have task info for second task
         expect(json.task).toBeDefined();
-        expect(json.task.name).toBe('second-task');
+        expect(json.task.id).toBe('002-second-task');
 
         // Should NOT include changeDocuments
         expect(json.changeDocuments).toBeUndefined();
@@ -858,7 +858,7 @@ status: in-progress
         });
 
         // Should show auto-completed message
-        expect(output).toContain('Auto-completed task: only-task');
+        expect(output).toContain('Auto-completed task: 001-only-task');
 
         // Should show all tasks complete
         expect(output).toContain('All tasks complete');
@@ -1078,7 +1078,7 @@ status: to-do
           `node ${openspecBin} get task --id 002-second-task`,
           { encoding: 'utf-8' }
         );
-        expect(output).toContain('Task 2: second-task');
+        expect(output).toContain('Task 2: 002-second-task');
         expect(output).toContain('Second item');
         expect(output).not.toContain('First item');
       } finally {
@@ -1144,7 +1144,7 @@ status: in-progress
         );
         const json = JSON.parse(output);
         expect(json.changeId).toBe('test-change');
-        expect(json.task.name).toBe('my-task');
+        expect(json.task.id).toBe('001-my-task');
       } finally {
         process.chdir(originalCwd);
       }
@@ -1737,9 +1737,9 @@ status: to-do
       });
       const json = JSON.parse(output);
       expect(json.tasks).toHaveLength(3);
-      expect(json.tasks.map((t: { name: string }) => t.name)).toContain('task-a');
-      expect(json.tasks.map((t: { name: string }) => t.name)).toContain('task-b');
-      expect(json.tasks.map((t: { name: string }) => t.name)).toContain('task-c');
+      expect(json.tasks.map((t: { id: string }) => t.id)).toContain('001-task-a');
+      expect(json.tasks.map((t: { id: string }) => t.id)).toContain('002-task-b');
+      expect(json.tasks.map((t: { id: string }) => t.id)).toContain('001-task-c');
     } finally {
       process.chdir(originalCwd);
     }
@@ -1844,5 +1844,206 @@ status: in-progress
     } finally {
       process.chdir(originalCwd);
     }
+  });
+
+  describe('task ID format', () => {
+    it('includes full filename (with sequence prefix) as ID in JSON output', async () => {
+      const changeDir = path.join(changesDir, 'test-change');
+      const tasksDir = path.join(changeDir, 'tasks');
+      await fs.mkdir(tasksDir, { recursive: true });
+
+      await fs.writeFile(
+        path.join(changeDir, 'proposal.md'),
+        '# Change: Test\n\n## Why\nTest\n\n## What Changes\n- Test'
+      );
+      await fs.writeFile(
+        path.join(tasksDir, '001-first-task.md'),
+        `---
+status: in-progress
+---
+# First Task`
+      );
+      await fs.writeFile(
+        path.join(tasksDir, '002-second-task.md'),
+        `---
+status: to-do
+---
+# Second Task`
+      );
+
+      const originalCwd = process.cwd();
+      try {
+        process.chdir(testDir);
+        const output = execSync(`node ${openspecBin} get tasks --json`, {
+          encoding: 'utf-8',
+        });
+        const json = JSON.parse(output);
+
+        // IDs should be full filenames without .md (e.g., "001-first-task")
+        const ids = json.tasks.map((t: { id: string }) => t.id);
+        expect(ids).toContain('001-first-task');
+        expect(ids).toContain('002-second-task');
+
+        // IDs should NOT contain change ID prefix
+        expect(ids.every((id: string) => !id.includes('/'))).toBe(true);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('displays full filename as ID in text output table', async () => {
+      const changeDir = path.join(changesDir, 'my-change');
+      const tasksDir = path.join(changeDir, 'tasks');
+      await fs.mkdir(tasksDir, { recursive: true });
+
+      await fs.writeFile(
+        path.join(changeDir, 'proposal.md'),
+        '# Change: My\n\n## Why\nTest\n\n## What Changes\n- Test'
+      );
+      await fs.writeFile(
+        path.join(tasksDir, '003-my-task.md'),
+        `---
+status: to-do
+---
+# My Task`
+      );
+
+      const originalCwd = process.cwd();
+      try {
+        process.chdir(testDir);
+        const output = execSync(`node ${openspecBin} get tasks`, {
+          encoding: 'utf-8',
+        });
+
+        // Should display "003-my-task" (full filename without .md)
+        expect(output).toContain('003-my-task');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('task ID from get tasks can be used with complete command', async () => {
+      const changeDir = path.join(changesDir, 'test-change');
+      const tasksDir = path.join(changeDir, 'tasks');
+      await fs.mkdir(tasksDir, { recursive: true });
+
+      await fs.writeFile(
+        path.join(changeDir, 'proposal.md'),
+        '# Change: Test\n\n## Why\nTest\n\n## What Changes\n- Test'
+      );
+      await fs.writeFile(
+        path.join(tasksDir, '001-completable-task.md'),
+        `---
+status: in-progress
+---
+# Completable Task
+
+## Implementation Checklist
+- [ ] Item one
+- [ ] Item two`
+      );
+
+      const originalCwd = process.cwd();
+      try {
+        process.chdir(testDir);
+
+        // Get the task ID from get tasks
+        const listOutput = execSync(`node ${openspecBin} get tasks --json`, {
+          encoding: 'utf-8',
+        });
+        const json = JSON.parse(listOutput);
+        const taskId = json.tasks[0].id;
+
+        // The ID should be usable with complete command
+        const completeOutput = execSync(
+          `node ${openspecBin} complete task --id ${taskId} --json`,
+          { encoding: 'utf-8' }
+        );
+        const completeJson = JSON.parse(completeOutput);
+        expect(completeJson.newStatus).toBe('done');
+        expect(completeJson.taskId).toBe('001-completable-task');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('task ID from get tasks can be used with undo command', async () => {
+      const changeDir = path.join(changesDir, 'test-change');
+      const tasksDir = path.join(changeDir, 'tasks');
+      await fs.mkdir(tasksDir, { recursive: true });
+
+      await fs.writeFile(
+        path.join(changeDir, 'proposal.md'),
+        '# Change: Test\n\n## Why\nTest\n\n## What Changes\n- Test'
+      );
+      await fs.writeFile(
+        path.join(tasksDir, '001-undoable-task.md'),
+        `---
+status: done
+---
+# Undoable Task
+
+## Implementation Checklist
+- [x] Done item`
+      );
+
+      const originalCwd = process.cwd();
+      try {
+        process.chdir(testDir);
+
+        // The task ID should work with undo command
+        const undoOutput = execSync(
+          `node ${openspecBin} undo task --id 001-undoable-task --json`,
+          { encoding: 'utf-8' }
+        );
+        const undoJson = JSON.parse(undoOutput);
+        expect(undoJson.newStatus).toBe('to-do');
+        expect(undoJson.taskId).toBe('001-undoable-task');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    it('includes full filename as ID in tasks list for specific change', async () => {
+      const changeDir = path.join(changesDir, 'specific-change');
+      const tasksDir = path.join(changeDir, 'tasks');
+      await fs.mkdir(tasksDir, { recursive: true });
+
+      await fs.writeFile(
+        path.join(changeDir, 'proposal.md'),
+        '# Change: Specific\n\n## Why\nTest\n\n## What Changes\n- Test'
+      );
+      await fs.writeFile(
+        path.join(tasksDir, '001-task-one.md'),
+        `---
+status: to-do
+---
+# Task One`
+      );
+      await fs.writeFile(
+        path.join(tasksDir, '002-task-two.md'),
+        `---
+status: to-do
+---
+# Task Two`
+      );
+
+      const originalCwd = process.cwd();
+      try {
+        process.chdir(testDir);
+        const output = execSync(
+          `node ${openspecBin} get tasks --id specific-change --json`,
+          { encoding: 'utf-8' }
+        );
+        const json = JSON.parse(output);
+
+        // IDs should be full filenames without .md
+        const ids = json.tasks.map((t: { id: string }) => t.id);
+        expect(ids).toContain('001-task-one');
+        expect(ids).toContain('002-task-two');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
   });
 });

--- a/test/commands/undo.test.ts
+++ b/test/commands/undo.test.ts
@@ -286,7 +286,7 @@ status: done
       const json = JSON.parse(output);
 
       expect(json.undoneTasks).toHaveLength(1);
-      expect(json.skippedTasks).toContain('todo');
+      expect(json.skippedTasks).toContain('001-todo');
     } finally {
       process.chdir(originalCwd);
     }
@@ -379,7 +379,7 @@ status: done
       );
       const json = JSON.parse(output);
 
-      expect(json.undoneTasks[0].taskId).toBe('test-change/task');
+      expect(json.undoneTasks[0].taskId).toBe('001-task');
       expect(json.undoneTasks[0].name).toBe('task');
       expect(json.undoneTasks[0].previousStatus).toBe('done');
       expect(json.undoneTasks[0].uncheckedItems).toContain('Checked item');

--- a/test/services/item-retrieval.test.ts
+++ b/test/services/item-retrieval.test.ts
@@ -194,8 +194,8 @@ status: in-progress
       expect(result).toHaveLength(2);
 
       const taskIds = result.map((t) => t.taskId);
-      expect(taskIds).toContain('change-a/todo');
-      expect(taskIds).toContain('change-b/wip');
+      expect(taskIds).toContain('002-todo');
+      expect(taskIds).toContain('001-wip');
     });
 
     it('should return empty array when no open tasks exist', async () => {

--- a/test/services/task-id.test.ts
+++ b/test/services/task-id.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getTaskId,
+  getTaskIdFromFilename,
+  parseTaskId,
+  normalizeTaskId,
+  isValidTaskId,
+} from '../../src/services/task-id.js';
+
+describe('TaskIdService', () => {
+  describe('getTaskId', () => {
+    it('should return task ID from task object', () => {
+      const task = { filename: '001-implement.md' };
+      expect(getTaskId(task)).toBe('001-implement');
+    });
+
+    it('should handle multi-word task names', () => {
+      const task = { filename: '002-update-templates.md' };
+      expect(getTaskId(task)).toBe('002-update-templates');
+    });
+
+    it('should handle high sequence numbers', () => {
+      const task = { filename: '999-final-task.md' };
+      expect(getTaskId(task)).toBe('999-final-task');
+    });
+  });
+
+  describe('getTaskIdFromFilename', () => {
+    it('should strip .md extension', () => {
+      expect(getTaskIdFromFilename('001-test.md')).toBe('001-test');
+    });
+
+    it('should return unchanged if no .md extension', () => {
+      expect(getTaskIdFromFilename('001-test')).toBe('001-test');
+    });
+
+    it('should only strip trailing .md', () => {
+      expect(getTaskIdFromFilename('001-test.md.backup')).toBe('001-test.md.backup');
+    });
+  });
+
+  describe('parseTaskId', () => {
+    it('should parse valid task ID', () => {
+      const result = parseTaskId('001-implement');
+      expect(result).not.toBeNull();
+      expect(result!.sequence).toBe(1);
+      expect(result!.name).toBe('implement');
+    });
+
+    it('should parse task ID with .md extension', () => {
+      const result = parseTaskId('002-review.md');
+      expect(result).not.toBeNull();
+      expect(result!.sequence).toBe(2);
+      expect(result!.name).toBe('review');
+    });
+
+    it('should parse multi-word task names', () => {
+      const result = parseTaskId('003-update-templates');
+      expect(result).not.toBeNull();
+      expect(result!.sequence).toBe(3);
+      expect(result!.name).toBe('update-templates');
+    });
+
+    it('should return null for invalid format (no sequence)', () => {
+      expect(parseTaskId('implement')).toBeNull();
+    });
+
+    it('should return null for invalid format (wrong sequence length)', () => {
+      expect(parseTaskId('01-test')).toBeNull();
+      expect(parseTaskId('1-test')).toBeNull();
+    });
+
+    it('should return null for invalid format (no name)', () => {
+      expect(parseTaskId('001-')).toBeNull();
+    });
+  });
+
+  describe('normalizeTaskId', () => {
+    it('should strip .md extension', () => {
+      expect(normalizeTaskId('001-test.md')).toBe('001-test');
+    });
+
+    it('should return unchanged if no .md extension', () => {
+      expect(normalizeTaskId('001-test')).toBe('001-test');
+    });
+
+    it('should handle empty string', () => {
+      expect(normalizeTaskId('')).toBe('');
+    });
+  });
+
+  describe('isValidTaskId', () => {
+    it('should return true for valid task ID', () => {
+      expect(isValidTaskId('001-implement')).toBe(true);
+    });
+
+    it('should return true for valid task ID with .md', () => {
+      expect(isValidTaskId('001-implement.md')).toBe(true);
+    });
+
+    it('should return true for multi-word names', () => {
+      expect(isValidTaskId('002-update-templates')).toBe(true);
+    });
+
+    it('should return false for invalid sequence length', () => {
+      expect(isValidTaskId('01-test')).toBe(false);
+      expect(isValidTaskId('1-test')).toBe(false);
+      expect(isValidTaskId('0001-test')).toBe(false);
+    });
+
+    it('should return false for missing sequence', () => {
+      expect(isValidTaskId('test')).toBe(false);
+      expect(isValidTaskId('test-task')).toBe(false);
+    });
+
+    it('should return false for missing name', () => {
+      expect(isValidTaskId('001-')).toBe(false);
+      expect(isValidTaskId('001')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace "Repeat until done" with "Stop and await user confirmation" in agent instructions
- Add complete CLI command reference table to CLAUDE.md/AGENTS.md stub (39 commands)
- Introduce `getTaskId()` for consistent task ID format (filename without .md)

## Test plan
- [ ] Run `plx get task` and verify agent stops after one task
- [ ] Run `plx update` and verify CLAUDE.md contains command reference table
- [ ] Run `npm test` to verify all tests pass

Fixes PLX-26