### PR TITLE
feat: add task type and blocked-by options to task creation and retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- **Task type system with template discovery**: Tasks now support typed templates for different kinds of work
+  - `type:` field in task frontmatter specifies the task category
+  - 12 built-in types: story, bug, business-logic, components, research, discovery, chore, refactor, infrastructure, documentation, release, implementation
+  - Template discovery scans `workspace/templates/` for custom templates with `type:` in frontmatter
+  - User templates automatically override built-in templates with the same type
+  - CLI support: `splx create task --type <type>` creates tasks from templates
+- **Task dependency tracking**: Tasks can declare dependencies on other tasks
+  - `blocked-by:` field in task frontmatter lists blocking task IDs
+  - Same-change syntax: `blocked-by: [001-component-name, 002-logic-name]`
+  - Cross-change syntax: `blocked-by: [other-change/001-task-name]`
+  - CLI support: `splx create task --blocked-by <task-ids>` sets dependencies
+  - Dependencies are advisory (warnings, not hard blocks) to help AI agents with task ordering
 - **Copy-review-request and copy-test-request slash commands**: New commands for external agent handoff
   - `/splx:copy-review-request` copies review request with workspace/REVIEW.md guidelines to clipboard
   - `/splx:copy-test-request` copies test request with workspace/TESTING.md configuration to clipboard
@@ -14,10 +26,14 @@
 - **PLX-managed template files moved to workspace directory**: Template files (ARCHITECTURE.md, REVIEW.md, RELEASE.md, TESTING.md) are now managed in workspace/ directory
   - Improves organization and keeps all PLX artifacts in one location
   - Maintains backward compatibility with root-level files during migration
+- **PROGRESS.md concept removed**: Simplified workflow by removing PROGRESS.md tracking
+  - Task management now handled entirely through task files and `splx get task` command
+  - Reduces complexity in multi-agent handoff workflows
 
 ### Fixed
 
 - **Package name restored to open-splx**: Fixed package name consistency across the codebase
+- **Task type validation**: Strict mode now warns when task type is missing or unrecognized
 
 ---
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -950,14 +950,18 @@ createCmd
   .option('--parent-id <id>', 'Link task to a parent (change or review)')
   .option('--parent-type <type>', 'Specify parent type: change or review')
   .option('--skill-level <level>', 'Task skill level: junior, medior, or senior')
+  .option('--type <type>', 'Task type (e.g., story, bug, business-logic, components, etc.)')
+  .option('--blocked-by <ids>', 'Comma-separated list of task IDs that block this task')
   .option('--json', 'Output as JSON')
-  .action(async (title: string, options: { parentId?: string; parentType?: string; skillLevel?: string; json?: boolean }) => {
+  .action(async (title: string, options: { parentId?: string; parentType?: string; skillLevel?: string; type?: string; blockedBy?: string; json?: boolean }) => {
     try {
       const createCommand = new CreateCommand();
       await createCommand.createTask(title, {
         parentId: options.parentId,
         parentType: options.parentType as 'change' | 'review' | 'spec' | undefined,
         skillLevel: options.skillLevel as 'junior' | 'medior' | 'senior' | undefined,
+        type: options.type,
+        blockedBy: options.blockedBy,
         json: options.json,
       });
     } catch (error) {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -174,7 +174,22 @@ export class CreateCommand {
 
     // Validate type if provided
     if (options.type) {
-      const availableTypes = await getAvailableTypes(workspaces[0].path);
+      // Determine the workspace in which the task will be created.
+      // If the parent ID is prefixed with a project name (e.g. "project-a/change-name"),
+      // prefer the workspace whose projectName matches that prefix.
+      let workspaceForTask = workspaces[0];
+      if (options.parentId) {
+        const slashIndex = options.parentId.indexOf('/');
+        if (slashIndex > 0) {
+          const projectPrefix = options.parentId.substring(0, slashIndex);
+          const matchedWorkspace = workspaces.find(ws => ws.projectName === projectPrefix);
+          if (matchedWorkspace) {
+            workspaceForTask = matchedWorkspace;
+          }
+        }
+      }
+
+      const availableTypes = await getAvailableTypes(workspaceForTask.path);
       const typeExists = availableTypes.some(t => t.type === options.type);
       if (!typeExists) {
         const typeList = availableTypes.map(t => t.type).join(', ');

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
-import { TemplateManager } from '../core/templates/index.js';
+import { TemplateManager, getAvailableTypes } from '../core/templates/index.js';
 import { getFilteredWorkspaces } from '../utils/workspace-filter.js';
 import { FileSystemUtils } from '../utils/file-system.js';
 import { ItemRetrievalService } from '../services/item-retrieval.js';
@@ -12,6 +12,8 @@ interface TaskOptions {
   parentId?: string;
   parentType?: 'change' | 'review' | 'spec';
   skillLevel?: 'junior' | 'medior' | 'senior';
+  type?: string;
+  blockedBy?: string;
   json?: boolean;
 }
 
@@ -170,6 +172,24 @@ export class CreateCommand {
       return;
     }
 
+    // Validate type if provided
+    if (options.type) {
+      const availableTypes = await getAvailableTypes(workspaces[0].path);
+      const typeExists = availableTypes.some(t => t.type === options.type);
+      if (!typeExists) {
+        const typeList = availableTypes.map(t => t.type).join(', ');
+        if (options.json) {
+          console.log(JSON.stringify({
+            error: `Unknown task type '${options.type}'. Available types: ${typeList}`
+          }));
+        } else {
+          ora().fail(`Unknown task type '${options.type}'. Available types: ${typeList}`);
+        }
+        process.exitCode = 1;
+        return;
+      }
+    }
+
     if (!options.parentId) {
       if (options.json) {
         console.log(JSON.stringify({
@@ -266,11 +286,22 @@ export class CreateCommand {
     });
     const filepath = path.join(tasksDir, filename);
 
+    // Parse blocked-by parameter
+    let blockedBy: string[] | undefined;
+    if (options.blockedBy) {
+      blockedBy = options.blockedBy
+        .split(',')
+        .map(id => id.trim())
+        .filter(id => id.length > 0);
+    }
+
     const content = TemplateManager.getTaskTemplate({
       title,
       skillLevel: options.skillLevel,
       parentType: actualParentType,
       parentId: parentItemId,
+      type: options.type,
+      blockedBy,
     });
 
     await FileSystemUtils.writeFile(filepath, content);
@@ -285,6 +316,8 @@ export class CreateCommand {
         parentId: parentItemId,
         parentType: actualParentType,
         taskId: `${parentItemId}-${kebabTitle}`,
+        ...(options.type && { taskType: options.type }),
+        ...(blockedBy && blockedBy.length > 0 && { blockedBy }),
       }, null, 2));
     } else {
       console.log(chalk.green(`\n✓ Created task: ${relativePath}\n`));

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -890,8 +890,11 @@ export class GetCommand {
           try {
             const content = fsSync.readFileSync(t.task.filepath, 'utf-8');
             taskType = parseType(content);
-          } catch {
-            // Ignore read errors
+          } catch (err) {
+            console.warn(
+              `Warning: Failed to read task file "${t.task.filepath}" to determine type:`,
+              err instanceof Error ? err.message : err
+            );
           }
 
           return {

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -971,8 +971,12 @@ export class GetCommand {
       try {
         const content = fsSync.readFileSync(task.filepath, 'utf-8');
         taskType = parseType(content);
-      } catch {
-        // Ignore read errors
+      } catch (error) {
+        console.error(
+          chalk.yellow(
+            `Warning: Failed to read task file "${task.filepath}" to determine type: ${error instanceof Error ? error.message : String(error)}`
+          )
+        );
       }
 
       const typeDisplay = taskType ? this.formatType(taskType) : chalk.dim('-');

--- a/src/core/configurators/slash/amazon-q.ts
+++ b/src/core/configurators/slash/amazon-q.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.amazonq/prompts/splx-refine-review.md',
   'refine-testing': '.amazonq/prompts/splx-refine-testing.md',
   'review': '.amazonq/prompts/splx-review.md',
+  'sync-tasks': '.amazonq/prompts/splx-sync-tasks.md',
   'sync-workspace': '.amazonq/prompts/splx-sync-workspace.md',
   'test': '.amazonq/prompts/splx-test.md',
   'undo-task': '.amazonq/prompts/splx-undo-task.md'
@@ -131,6 +132,11 @@ description: Create or update TESTING.md.
 <arguments>$ARGUMENTS</arguments>`,
   'review': `---
 description: Review implementations against specs, changes, or tasks.
+---
+
+<arguments>$ARGUMENTS</arguments>`,
+  'sync-tasks': `---
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
 ---
 
 <arguments>$ARGUMENTS</arguments>`,

--- a/src/core/configurators/slash/antigravity.ts
+++ b/src/core/configurators/slash/antigravity.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.agent/workflows/splx-refine-review.md',
   'refine-testing': '.agent/workflows/splx-refine-testing.md',
   'review': '.agent/workflows/splx-review.md',
+  'sync-tasks': '.agent/workflows/splx-sync-tasks.md',
   'sync-workspace': '.agent/workflows/splx-sync-workspace.md',
   'test': '.agent/workflows/splx-test.md',
   'undo-task': '.agent/workflows/splx-undo-task.md'
@@ -46,6 +47,7 @@ const DESCRIPTIONS: Record<SlashCommandId, string> = {
   'refine-review': 'Create or update REVIEW.md.',
   'refine-testing': 'Create or update TESTING.md.',
   'review': 'Review implementations against specs, changes, or tasks.',
+  'sync-tasks': 'Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).',
   'sync-workspace': 'Scan workspace state and suggest maintenance actions.',
   'test': 'Run tests based on scope (change, task, or spec) using TESTING.md configuration.',
   'undo-task': 'Revert a task to to-do.'

--- a/src/core/configurators/slash/auggie.ts
+++ b/src/core/configurators/slash/auggie.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.augment/commands/splx-refine-review.md',
   'refine-testing': '.augment/commands/splx-refine-testing.md',
   'review': '.augment/commands/splx-review.md',
+  'sync-tasks': '.augment/commands/splx-sync-tasks.md',
   'sync-workspace': '.augment/commands/splx-sync-workspace.md',
   'test': '.augment/commands/splx-test.md',
   'undo-task': '.augment/commands/splx-undo-task.md'
@@ -102,6 +103,10 @@ argument-hint: (optional context)
   'review': `---
 description: Review implementations against specs, changes, or tasks.
 argument-hint: (optional context)
+---`,
+  'sync-tasks': `---
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+argument-hint: change-id
 ---`,
   'sync-workspace': `---
 description: Scan workspace state and suggest maintenance actions.

--- a/src/core/configurators/slash/base.ts
+++ b/src/core/configurators/slash/base.ts
@@ -28,6 +28,7 @@ const ALL_COMMANDS: SlashCommandId[] = [
   'refine-review',
   'refine-testing',
   'review',
+  'sync-tasks',
   'sync-workspace',
   'test',
   'undo-task'

--- a/src/core/configurators/slash/claude.ts
+++ b/src/core/configurators/slash/claude.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.claude/commands/splx/refine-review.md',
   'refine-testing': '.claude/commands/splx/refine-testing.md',
   'review': '.claude/commands/splx/review.md',
+  'sync-tasks': '.claude/commands/splx/sync-tasks.md',
   'sync-workspace': '.claude/commands/splx/sync-workspace.md',
   'test': '.claude/commands/splx/test.md',
   'undo-task': '.claude/commands/splx/undo-task.md'
@@ -140,6 +141,12 @@ name: Review
 description: Review implementations against specs, changes, or tasks.
 category: OpenSplx
 tags: [splx, review, workflow]
+---`,
+  'sync-tasks': `---
+name: Sync Tasks
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+category: OpenSplx
+tags: [splx, sync, external, mcp]
 ---`,
   'sync-workspace': `---
 name: Sync Workspace

--- a/src/core/configurators/slash/cline.ts
+++ b/src/core/configurators/slash/cline.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.clinerules/workflows/splx-refine-review.md',
   'refine-testing': '.clinerules/workflows/splx-refine-testing.md',
   'review': '.clinerules/workflows/splx-review.md',
+  'sync-tasks': '.clinerules/workflows/splx-sync-tasks.md',
   'sync-workspace': '.clinerules/workflows/splx-sync-workspace.md',
   'test': '.clinerules/workflows/splx-test.md',
   'undo-task': '.clinerules/workflows/splx-undo-task.md'
@@ -84,6 +85,9 @@ Create or update TESTING.md.`,
   'review': `# PLX: Review
 
 Review implementations against specs, changes, or tasks.`,
+  'sync-tasks': `# PLX: Sync Tasks
+
+Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).`,
   'sync-workspace': `# PLX: Sync Workspace
 
 Scan workspace state and suggest maintenance actions.`,

--- a/src/core/configurators/slash/codebuddy.ts
+++ b/src/core/configurators/slash/codebuddy.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.codebuddy/commands/splx/refine-review.md',
   'refine-testing': '.codebuddy/commands/splx/refine-testing.md',
   'review': '.codebuddy/commands/splx/review.md',
+  'sync-tasks': '.codebuddy/commands/splx/sync-tasks.md',
   'sync-workspace': '.codebuddy/commands/splx/sync-workspace.md',
   'test': '.codebuddy/commands/splx/test.md',
   'undo-task': '.codebuddy/commands/splx/undo-task.md'
@@ -140,6 +141,12 @@ name: Review
 description: Review implementations against specs, changes, or tasks.
 category: OpenSplx
 tags: [splx, review, workflow]
+---`,
+  'sync-tasks': `---
+name: Sync Tasks
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+category: OpenSplx
+tags: [splx, sync, external, mcp]
 ---`,
   'sync-workspace': `---
 name: Sync Workspace

--- a/src/core/configurators/slash/codex.ts
+++ b/src/core/configurators/slash/codex.ts
@@ -25,6 +25,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.codex/prompts/splx-refine-review.md',
   'refine-testing': '.codex/prompts/splx-refine-testing.md',
   'review': '.codex/prompts/splx-review.md',
+  'sync-tasks': '.codex/prompts/splx-sync-tasks.md',
   'sync-workspace': '.codex/prompts/splx-sync-workspace.md',
   'test': '.codex/prompts/splx-test.md',
   'undo-task': '.codex/prompts/splx-undo-task.md'
@@ -142,6 +143,12 @@ $ARGUMENTS`,
   'review': `---
 description: Review implementations against specs, changes, or tasks.
 argument-hint: (optional context)
+---
+
+$ARGUMENTS`,
+  'sync-tasks': `---
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+argument-hint: change-id
 ---
 
 $ARGUMENTS`,

--- a/src/core/configurators/slash/costrict.ts
+++ b/src/core/configurators/slash/costrict.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.cospec/splx/commands/splx-refine-review.md',
   'refine-testing': '.cospec/splx/commands/splx-refine-testing.md',
   'review': '.cospec/splx/commands/splx-review.md',
+  'sync-tasks': '.cospec/splx/commands/splx-sync-tasks.md',
   'sync-workspace': '.cospec/splx/commands/splx-sync-workspace.md',
   'test': '.cospec/splx/commands/splx-test.md',
   'undo-task': '.cospec/splx/commands/splx-undo-task.md'
@@ -102,6 +103,10 @@ argument-hint: (optional context)
   'review': `---
 description: "Review implementations against specs, changes, or tasks."
 argument-hint: (optional context)
+---`,
+  'sync-tasks': `---
+description: "Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira)."
+argument-hint: change-id
 ---`,
   'sync-workspace': `---
 description: "Scan workspace state and suggest maintenance actions."

--- a/src/core/configurators/slash/crush.ts
+++ b/src/core/configurators/slash/crush.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.crush/commands/splx/refine-review.md',
   'refine-testing': '.crush/commands/splx/refine-testing.md',
   'review': '.crush/commands/splx/review.md',
+  'sync-tasks': '.crush/commands/splx/sync-tasks.md',
   'sync-workspace': '.crush/commands/splx/sync-workspace.md',
   'test': '.crush/commands/splx/test.md',
   'undo-task': '.crush/commands/splx/undo-task.md'
@@ -140,6 +141,12 @@ name: Review
 description: Review implementations against specs, changes, or tasks.
 category: OpenSplx
 tags: [splx, review, workflow]
+---`,
+  'sync-tasks': `---
+name: Sync Tasks
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+category: OpenSplx
+tags: [splx, sync, external, mcp]
 ---`,
   'sync-workspace': `---
 name: Sync Workspace

--- a/src/core/configurators/slash/cursor.ts
+++ b/src/core/configurators/slash/cursor.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.cursor/commands/splx-refine-review.md',
   'refine-testing': '.cursor/commands/splx-refine-testing.md',
   'review': '.cursor/commands/splx-review.md',
+  'sync-tasks': '.cursor/commands/splx-sync-tasks.md',
   'sync-workspace': '.cursor/commands/splx-sync-workspace.md',
   'test': '.cursor/commands/splx-test.md',
   'undo-task': '.cursor/commands/splx-undo-task.md'
@@ -140,6 +141,12 @@ name: /splx-review
 id: splx-review
 category: OpenSplx
 description: Review implementations against specs, changes, or tasks.
+---`,
+  'sync-tasks': `---
+name: /splx-sync-tasks
+id: splx-sync-tasks
+category: OpenSplx
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
 ---`,
   'sync-workspace': `---
 name: /splx-sync-workspace

--- a/src/core/configurators/slash/factory.ts
+++ b/src/core/configurators/slash/factory.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.factory/commands/splx-refine-review.md',
   'refine-testing': '.factory/commands/splx-refine-testing.md',
   'review': '.factory/commands/splx-review.md',
+  'sync-tasks': '.factory/commands/splx-sync-tasks.md',
   'sync-workspace': '.factory/commands/splx-sync-workspace.md',
   'test': '.factory/commands/splx-test.md',
   'undo-task': '.factory/commands/splx-undo-task.md'
@@ -102,6 +103,10 @@ argument-hint: (optional context)
   'review': `---
 description: Review implementations against specs, changes, or tasks.
 argument-hint: (optional context)
+---`,
+  'sync-tasks': `---
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+argument-hint: change-id
 ---`,
   'sync-workspace': `---
 description: Scan workspace state and suggest maintenance actions.

--- a/src/core/configurators/slash/gemini.ts
+++ b/src/core/configurators/slash/gemini.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.gemini/commands/splx/refine-review.toml',
   'refine-testing': '.gemini/commands/splx/refine-testing.toml',
   'review': '.gemini/commands/splx/review.toml',
+  'sync-tasks': '.gemini/commands/splx/sync-tasks.toml',
   'sync-workspace': '.gemini/commands/splx/sync-workspace.toml',
   'test': '.gemini/commands/splx/test.toml',
   'undo-task': '.gemini/commands/splx/undo-task.toml'
@@ -46,6 +47,7 @@ const DESCRIPTIONS: Record<SlashCommandId, string> = {
   'refine-review': 'Create or update REVIEW.md.',
   'refine-testing': 'Create or update TESTING.md.',
   'review': 'Review implementations against specs, changes, or tasks.',
+  'sync-tasks': 'Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).',
   'sync-workspace': 'Scan workspace state and suggest maintenance actions.',
   'test': 'Run tests based on scope (change, task, or spec) using TESTING.md configuration.',
   'undo-task': 'Revert a task to to-do.'

--- a/src/core/configurators/slash/github-copilot.ts
+++ b/src/core/configurators/slash/github-copilot.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.github/prompts/splx-refine-review.prompt.md',
   'refine-testing': '.github/prompts/splx-refine-testing.prompt.md',
   'review': '.github/prompts/splx-review.prompt.md',
+  'sync-tasks': '.github/prompts/splx-sync-tasks.prompt.md',
   'sync-workspace': '.github/prompts/splx-sync-workspace.prompt.md',
   'test': '.github/prompts/splx-test.prompt.md',
   'undo-task': '.github/prompts/splx-undo-task.prompt.md'
@@ -119,6 +120,11 @@ description: Create or update TESTING.md.
 $ARGUMENTS`,
   'review': `---
 description: Review implementations against specs, changes, or tasks.
+---
+
+$ARGUMENTS`,
+  'sync-tasks': `---
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
 ---
 
 $ARGUMENTS`,

--- a/src/core/configurators/slash/iflow.ts
+++ b/src/core/configurators/slash/iflow.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.iflow/commands/splx-refine-review.md',
   'refine-testing': '.iflow/commands/splx-refine-testing.md',
   'review': '.iflow/commands/splx-review.md',
+  'sync-tasks': '.iflow/commands/splx-sync-tasks.md',
   'sync-workspace': '.iflow/commands/splx-sync-workspace.md',
   'test': '.iflow/commands/splx-test.md',
   'undo-task': '.iflow/commands/splx-undo-task.md'
@@ -140,6 +141,12 @@ name: /splx-review
 id: splx-review
 category: OpenSplx
 description: Review implementations against specs, changes, or tasks.
+---`,
+  'sync-tasks': `---
+name: /splx-sync-tasks
+id: splx-sync-tasks
+category: OpenSplx
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
 ---`,
   'sync-workspace': `---
 name: /splx-sync-workspace

--- a/src/core/configurators/slash/kilocode.ts
+++ b/src/core/configurators/slash/kilocode.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.kilocode/workflows/splx-refine-review.md',
   'refine-testing': '.kilocode/workflows/splx-refine-testing.md',
   'review': '.kilocode/workflows/splx-review.md',
+  'sync-tasks': '.kilocode/workflows/splx-sync-tasks.md',
   'sync-workspace': '.kilocode/workflows/splx-sync-workspace.md',
   'test': '.kilocode/workflows/splx-test.md',
   'undo-task': '.kilocode/workflows/splx-undo-task.md'

--- a/src/core/configurators/slash/opencode.ts
+++ b/src/core/configurators/slash/opencode.ts
@@ -23,6 +23,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.opencode/command/splx-refine-review.md',
   'refine-testing': '.opencode/command/splx-refine-testing.md',
   'review': '.opencode/command/splx-review.md',
+  'sync-tasks': '.opencode/command/splx-sync-tasks.md',
   'sync-workspace': '.opencode/command/splx-sync-workspace.md',
   'test': '.opencode/command/splx-test.md',
   'undo-task': '.opencode/command/splx-undo-task.md'
@@ -145,6 +146,12 @@ $ARGUMENTS`,
   'review': `---
 description: Review implementations against specs, changes, or tasks.
 argument-hint: (optional context)
+---
+
+$ARGUMENTS`,
+  'sync-tasks': `---
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+argument-hint: change-id
 ---
 
 $ARGUMENTS`,

--- a/src/core/configurators/slash/qoder.ts
+++ b/src/core/configurators/slash/qoder.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.qoder/commands/splx/refine-review.md',
   'refine-testing': '.qoder/commands/splx/refine-testing.md',
   'review': '.qoder/commands/splx/review.md',
+  'sync-tasks': '.qoder/commands/splx/sync-tasks.md',
   'sync-workspace': '.qoder/commands/splx/sync-workspace.md',
   'test': '.qoder/commands/splx/test.md',
   'undo-task': '.qoder/commands/splx/undo-task.md'
@@ -140,6 +141,12 @@ name: Review
 description: Review implementations against specs, changes, or tasks.
 category: OpenSplx
 tags: [splx, review, workflow]
+---`,
+  'sync-tasks': `---
+name: Sync Tasks
+description: Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).
+category: OpenSplx
+tags: [splx, sync, external, mcp]
 ---`,
   'sync-workspace': `---
 name: Sync Workspace

--- a/src/core/configurators/slash/qwen.ts
+++ b/src/core/configurators/slash/qwen.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.qwen/commands/splx-refine-review.toml',
   'refine-testing': '.qwen/commands/splx-refine-testing.toml',
   'review': '.qwen/commands/splx-review.toml',
+  'sync-tasks': '.qwen/commands/splx-sync-tasks.toml',
   'sync-workspace': '.qwen/commands/splx-sync-workspace.toml',
   'test': '.qwen/commands/splx-test.toml',
   'undo-task': '.qwen/commands/splx-undo-task.toml'
@@ -46,6 +47,7 @@ const DESCRIPTIONS: Record<SlashCommandId, string> = {
   'refine-review': 'Create or update REVIEW.md.',
   'refine-testing': 'Create or update TESTING.md.',
   'review': 'Review implementations against specs, changes, or tasks.',
+  'sync-tasks': 'Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).',
   'sync-workspace': 'Scan workspace state and suggest maintenance actions.',
   'test': 'Run tests based on scope (change, task, or spec) using TESTING.md configuration.',
   'undo-task': 'Revert a task to to-do.'

--- a/src/core/configurators/slash/roocode.ts
+++ b/src/core/configurators/slash/roocode.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.roo/commands/splx-refine-review.md',
   'refine-testing': '.roo/commands/splx-refine-testing.md',
   'review': '.roo/commands/splx-review.md',
+  'sync-tasks': '.roo/commands/splx-sync-tasks.md',
   'sync-workspace': '.roo/commands/splx-sync-workspace.md',
   'test': '.roo/commands/splx-test.md',
   'undo-task': '.roo/commands/splx-undo-task.md'
@@ -84,6 +85,9 @@ Create or update TESTING.md.`,
   'review': `# PLX: Review
 
 Review implementations against specs, changes, or tasks.`,
+  'sync-tasks': `# PLX: Sync Tasks
+
+Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).`,
   'sync-workspace': `# PLX: Sync Workspace
 
 Scan workspace state and suggest maintenance actions.`,

--- a/src/core/configurators/slash/windsurf.ts
+++ b/src/core/configurators/slash/windsurf.ts
@@ -21,6 +21,7 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
   'refine-review': '.windsurf/workflows/splx-refine-review.md',
   'refine-testing': '.windsurf/workflows/splx-refine-testing.md',
   'review': '.windsurf/workflows/splx-review.md',
+  'sync-tasks': '.windsurf/workflows/splx-sync-tasks.md',
   'sync-workspace': '.windsurf/workflows/splx-sync-workspace.md',
   'test': '.windsurf/workflows/splx-test.md',
   'undo-task': '.windsurf/workflows/splx-undo-task.md'
@@ -46,6 +47,7 @@ const DESCRIPTIONS: Record<SlashCommandId, string> = {
   'refine-review': 'Create or update REVIEW.md.',
   'refine-testing': 'Create or update TESTING.md.',
   'review': 'Review implementations against specs, changes, or tasks.',
+  'sync-tasks': 'Sync tasks with external project management tools via MCPs (Linear, GitHub, Jira).',
   'sync-workspace': 'Scan workspace state and suggest maintenance actions.',
   'test': 'Run tests based on scope (change, task, or spec) using TESTING.md configuration.',
   'undo-task': 'Revert a task to to-do.'

--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -192,8 +192,8 @@ export class MarkdownParser {
             const items = value.slice(1, -1).split(',').map(item => item.trim()).filter(item => item);
             if (items.length > 0) {
               result.blockedBy = items;
-              inBlockedBy = false;
             }
+            inBlockedBy = false;
           }
           continue;
         } else {

--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -14,6 +14,8 @@ export interface Frontmatter {
   status?: string;
   archivedAt?: string;
   specUpdatesApplied?: boolean;
+  type?: string;
+  blockedBy?: string[];
   raw?: Record<string, unknown>;
 }
 
@@ -162,8 +164,10 @@ export class MarkdownParser {
   private static parseSimpleYaml(lines: string[]): Frontmatter {
     const result: Frontmatter = { raw: {} };
     const trackedIssues: TrackedIssue[] = [];
+    const blockedBy: string[] = [];
 
     let inTrackedIssues = false;
+    let inBlockedBy = false;
     let currentIssue: Partial<TrackedIssue> | null = null;
 
     for (const line of lines) {
@@ -176,9 +180,25 @@ export class MarkdownParser {
 
         if (key === 'tracked-issues') {
           inTrackedIssues = true;
+          inBlockedBy = false;
+          continue;
+        } else if (key === 'blocked-by') {
+          inBlockedBy = true;
+          inTrackedIssues = false;
+          currentIssue = null;
+
+          // Handle inline array format: blocked-by: [item1, item2]
+          if (value.startsWith('[') && value.endsWith(']')) {
+            const items = value.slice(1, -1).split(',').map(item => item.trim()).filter(item => item);
+            if (items.length > 0) {
+              result.blockedBy = items;
+              inBlockedBy = false;
+            }
+          }
           continue;
         } else {
           inTrackedIssues = false;
+          inBlockedBy = false;
           currentIssue = null;
         }
 
@@ -186,6 +206,19 @@ export class MarkdownParser {
           result.parentType = value;
         } else if (key === 'parent-id' && value) {
           result.parentId = value;
+        } else if (key === 'type' && value) {
+          result.type = value;
+        }
+      }
+
+      // Handle multi-line blocked-by array
+      if (inBlockedBy) {
+        const arrayItemMatch = line.match(/^\s+-\s+(.+)$/);
+        if (arrayItemMatch) {
+          const item = arrayItemMatch[1].trim().replace(/^["']|["']$/g, '');
+          if (item) {
+            blockedBy.push(item);
+          }
         }
       }
 
@@ -216,6 +249,10 @@ export class MarkdownParser {
 
     if (trackedIssues.length > 0) {
       result.trackedIssues = trackedIssues;
+    }
+
+    if (blockedBy.length > 0) {
+      result.blockedBy = blockedBy;
     }
 
     return result;

--- a/src/core/templates/agents-template.ts
+++ b/src/core/templates/agents-template.ts
@@ -308,6 +308,10 @@ status: to-do
 skill-level: junior|medior|senior
 parent-type: change
 parent-id: add-feature
+type: implementation
+blocked-by:
+  - 001-add-feature-components
+  - 002-add-feature-business-logic
 ---
 
 # Task: Implement feature
@@ -364,6 +368,103 @@ For non-Claude models, the agent determines an equivalent model or ignores the f
 - Add \`skill-level\` to task frontmatter during proposal creation
 - \`splx validate change --id <id> --strict\` warns when skill-level is missing
 - Skill level appears in \`splx get task\` output
+
+### Task Templates
+
+Task templates are Markdown files stored in \`workspace/templates/\` that define reusable task structures for different types of work. Templates are discovered via frontmatter \`type:\` field.
+
+**How It Works:**
+1. Create a Markdown file in \`workspace/templates/\` with frontmatter containing \`type: <name>\`
+2. Template discovery scans for all .md files with \`type:\` in frontmatter
+3. User templates automatically override built-in templates with the same type
+4. When creating tasks, you can reference any available type in the \`type:\` field
+
+**Built-in Types** (12 templates provided by default):
+
+| Type | Title Format | Purpose |
+|------|-------------|---------|
+| story | ✨ <Actor> is able to <capability> | User-facing features with business value |
+| bug | 🐞 <Thing> fails when <condition> | Bug fixes restoring intended behavior |
+| business-logic | ⚙️ <Feature> business logic | ViewModels, Services, APIs, DTOs, tests |
+| components | 🧩 <Feature> UI components | Stateless UI components and widgets |
+| research | 🔬 Investigate <unknown> | Best practices research and package evaluation |
+| discovery | 💡 Explore <idea> | Idea exploration and problem validation |
+| chore | 🧹 <Verb> <thing> | Maintenance, cleanup, housekeeping |
+| refactor | 🧱 Refactor <component> to <goal> | Code restructuring without behavior changes |
+| infrastructure | 🏗️ Set up <infrastructure> | CI/CD, deployment, hosting, DevOps |
+| documentation | 📄 Document <thing> | READMEs, API docs, architecture guides |
+| release | 🚀 Prepare release v<version> | Version bumping, changelog, release prep |
+| implementation | 🔧 Wire <feature> to business logic | Integration work wiring components to logic |
+
+**Creating Custom Templates:**
+When no built-in template matches your use case, propose a new type:
+
+1. Create \`workspace/templates/custom-type.md\`
+2. Add frontmatter: \`---\ntype: custom-type\n---\`
+3. Write template structure following conventions
+4. New type becomes immediately available and valid
+5. Reference it in task \`type:\` field
+
+**User Templates Override:**
+Create a file with the same \`type:\` in \`workspace/templates/\` to override any built-in template. This is useful for project-specific customization of standard types.
+
+### Task Dependencies
+
+Tasks can declare dependencies using the \`blocked-by:\` field in frontmatter. This allows sequencing work logically.
+
+**Syntax:**
+- Same-change tasks: \`blocked-by: [001-component-name, 002-logic-name]\`
+- Cross-change tasks: \`blocked-by: [other-change/001-task-name]\`
+- Can reference task IDs or full task file names
+
+**Important:**
+- Dependencies are **advisory only** - warnings, not hard blocks
+- AI agents use \`blocked-by\` for task ordering and planning
+- Dependencies help prevent ordering mistakes but don't prevent task creation
+- Document blockers to improve change coordination
+
+**Example:**
+\`\`\`yaml
+---
+status: to-do
+type: implementation
+blocked-by:
+  - 001-add-feature-components
+  - 002-add-feature-business-logic
+---
+\`\`\`
+
+### Recommended Task Ordering
+
+Follow this proven ordering pattern for features:
+
+1. **Components Task** (🧩 UI components)
+   - Create stateless UI components first
+   - Test in isolation before connecting to logic
+   - Establishes visual contract
+
+2. **Business Logic Task** (⚙️ business logic)
+   - Implement ViewModels, Services, APIs, DTOs
+   - Write unit tests
+   - Ready for connection to UI
+
+3. **Implementation Task** (🔧 wire to business logic)
+   - Connect components to ViewModels/Services
+   - Wire data flow end-to-end
+   - Write integration tests
+
+**Why This Order:**
+- UI-first prevents discovering logic gaps too late
+- Bottom-up testing (tests → logic → integration)
+- Parallel work possible: logic can proceed while UI designed
+- Reduces rework when UI and logic don't align
+
+**Other Recommended Patterns:**
+- Research (🔬) before implementation to validate approaches
+- Discovery (💡) before Research to validate ideas
+- Refactor (🧱) after features stabilize
+- Documentation (📄) as features complete
+- Infrastructure (🏗️) when deployment needs emerge
 
 5. **Create design.md when needed:**
 Create \`design.md\` if any of the following apply; otherwise omit it:

--- a/src/core/templates/index.ts
+++ b/src/core/templates/index.ts
@@ -87,3 +87,11 @@ export type { TaskContext } from './task-template.js';
 export type { ChangeContext } from './change-template.js';
 export type { SpecContext } from './spec-template.js';
 export type { RequestContext } from './request-template.js';
+
+export {
+  discoverTemplates,
+  getBuiltInTemplates,
+  getAvailableTypes,
+  getTemplateByType,
+  type TemplateInfo,
+} from './template-discovery.js';

--- a/src/core/templates/task-template.ts
+++ b/src/core/templates/task-template.ts
@@ -3,11 +3,21 @@ export interface TaskContext {
   skillLevel?: 'junior' | 'medior' | 'senior';
   parentType?: 'change' | 'review';
   parentId?: string;
+  type?: string;
+  blockedBy?: string[];
 }
 
-export const taskTemplate = (context: TaskContext): string => `---
-status: to-do${context.skillLevel ? `\nskill-level: ${context.skillLevel}` : ''}${context.parentType ? `\nparent-type: ${context.parentType}` : ''}${context.parentId ? `\nparent-id: ${context.parentId}` : ''}
----
+export const taskTemplate = (context: TaskContext): string => {
+  let frontmatter = `---
+status: to-do${context.skillLevel ? `\nskill-level: ${context.skillLevel}` : ''}${context.parentType ? `\nparent-type: ${context.parentType}` : ''}${context.parentId ? `\nparent-id: ${context.parentId}` : ''}${context.type ? `\ntype: ${context.type}` : ''}`;
+
+  if (context.blockedBy && context.blockedBy.length > 0) {
+    frontmatter += `\nblocked-by:\n${context.blockedBy.map(id => `  - ${id}`).join('\n')}`;
+  }
+
+  frontmatter += '\n---';
+
+  return `${frontmatter}
 
 # Task: ${context.title}
 
@@ -32,3 +42,4 @@ TBD - Expected state after this task.
 ## Notes
 TBD - Additional context if needed.
 `;
+};

--- a/src/core/templates/template-discovery.ts
+++ b/src/core/templates/template-discovery.ts
@@ -1331,10 +1331,9 @@ export async function discoverTemplates(workspacePath: string): Promise<Template
         const content = await fs.readFile(filePath, 'utf-8');
 
         // Use MarkdownParser to extract frontmatter and get the type
-        const parser = new MarkdownParser();
-        const parsed = parser.parse(content);
-        const frontmatter: any = (parsed as any)?.frontmatter ?? (parsed as any)?.metadata ?? (parsed as any)?.data;
-        const typeValue = frontmatter && typeof frontmatter.type === 'string' ? frontmatter.type : null;
+        const parser = new MarkdownParser(content);
+        const frontmatter = parser.getFrontmatter();
+        const typeValue = frontmatter?.type;
 
         // Skip files without valid type in frontmatter
         if (!typeValue) {

--- a/src/core/templates/template-discovery.ts
+++ b/src/core/templates/template-discovery.ts
@@ -1,0 +1,1447 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { MarkdownParser } from '../parsers/markdown-parser.js';
+
+export interface TemplateInfo {
+  type: string;
+  content: string;
+  source: 'built-in' | 'user';
+  filePath?: string;
+}
+
+// Built-in template contents
+const BUILT_IN_TEMPLATES: Record<string, string> = {
+  story: `---
+type: story
+---
+
+# ✨ Story Template
+
+Use this template for user-facing features with clear business value.
+
+**Title Format**: \`✨ <Actor> is able to <capability>\`
+
+**Examples**:
+- ✨ User is able to reset password via email
+- ✨ Admin is able to manage user roles
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 👤 User Story
+> Who benefits and what do they want to achieve?
+
+\`\`\`text
+As a {Actor}, I want to [action], so that [benefit/value].
+\`\`\`
+
+## 🚀 End Goal
+> What is the tangible, measurable end goal?
+
+<!-- REPLACE: Clear, SMART end goal statement -->
+
+## 📍 Currently
+> What is the current state?
+
+<!-- REPLACE: Description of current state -->
+
+## 🎯 Should
+> What should the state be after implementation?
+
+<!-- REPLACE: Description of target state -->
+
+## 🔧 Considerations (Non-Functional)
+> What non-functional requirements apply (performance, security, UX, etc.)?
+
+<!-- REPLACE: Non-functional requirements -->
+
+## 🗺️ User Journeys
+> What do different scenarios of { 👤 User, 🧠 System, 🎨 Screen } steps look like?
+
+1. 👤 User [verb] ...
+2. 🧠 System [verb] ...
+3. 🎨 Screen [verb] ...
+
+\`\`\`mermaid
+sequenceDiagram
+    participant 👤 User
+    participant 🧠 System
+    participant 🎨 Screen
+
+\`\`\`
+
+## 🎨 UI
+> What does the updated UI look like in ASCII?
+
+\`\`\`text
+<!-- REPLACE: ASCII representation of the updated UI -->
+\`\`\`
+
+## 📈 Data Flow Diagrams
+> How does data flow?
+
+\`\`\`mermaid
+<!-- REPLACE: Full data flow diagram -->
+\`\`\`
+
+## ✅ Acceptance Criteria
+> How do we measure successful achievement of end goal?
+
+- [ ] <!-- REPLACE: Criterion 1 -->
+- [ ] <!-- REPLACE: Criterion 2 -->
+
+## ⚠️ Constraints
+> What limitations or constraints exist?
+
+- [ ] <!-- REPLACE: Constraint 1 -->
+- [ ] <!-- REPLACE: Constraint 2 -->
+
+## 🏗️ Project Conventions
+> What are the relevant project's folder structure, naming conventions, and patterns?
+
+### Folder Structure
+
+<!-- REPLACE: Relevant folder structure -->
+
+### Naming Conventions
+
+<!-- REPLACE: File naming, class naming, variable naming conventions -->
+
+### Code Patterns
+
+<!-- REPLACE: Patterns used in this project -->
+
+## 📚 Existing Patterns
+> What similar implementations exist in the codebase that can be referenced?
+
+### Similar Features
+| Feature | Location | Relevance |
+|---------|----------|-----------|
+| <!-- REPLACE --> | <!-- REPLACE --> | <!-- REPLACE --> |
+
+### Reusable Components
+
+<!-- REPLACE: Existing components/services that can be reused -->
+
+## 📦 Preferred Packages
+> What packages does the user prefer or require?
+
+- [ ] <!-- REPLACE: Package name --> - <!-- REPLACE: Purpose -->
+`,
+
+  bug: `---
+type: bug
+---
+
+# 🐞 Bug Template
+
+Use this template for bug fixes that restore intended behavior.
+
+**Title Format**: \`🐞 <Thing> fails when <condition>\`
+
+**Examples**:
+- 🐞 Login fails when password contains special characters
+- 🐞 Invoice total is calculated incorrectly
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 💥 Event
+> When did the problem occur?
+
+\`\`\`text
+<!-- REPLACE: Date/time and context of bug occurrence -->
+\`\`\`
+
+## 🦋 Expected Result
+> What did you expect to happen?
+
+\`\`\`text
+<!-- REPLACE: Expected behavior -->
+\`\`\`
+
+## 🐛 Actual Result
+> What actually happened?
+
+\`\`\`text
+<!-- REPLACE: Actual behavior observed -->
+\`\`\`
+
+## 👣 Steps to Reproduce
+> Which steps can we take to reproduce the problem?
+
+1. [ ] <!-- REPLACE: Step 1 -->
+2. [ ] <!-- REPLACE: Step 2 -->
+3. [ ] <!-- REPLACE: Step 3 -->
+
+## 🌍 Environment
+> Where did the bug occur? (OS, browser, app version, device, auth state, etc.)
+
+- <!-- REPLACE: Environment details -->
+
+## ✅ Acceptance Criteria
+> How do we measure the successful fix of the bug?
+
+- [ ] <!-- REPLACE: Criterion 1 -->
+- [ ] <!-- REPLACE: Criterion 2 -->
+
+## 🧪 TDD Gherkin Regression Tests
+> What test(s) MUST be written to verify this bug exists and prevent recurrence?
+
+- [ ] \`Given <!-- REPLACE --> When <!-- REPLACE --> Then <!-- REPLACE -->\`
+
+## 📝 Suggested Approach
+> Which high level steps should we consider?
+
+1. [ ] First, create failing regression tests that confirm the bug exists
+2. [ ] <!-- REPLACE: Fix steps -->
+3. [ ] Verify end goal is reached, all tests succeed
+`,
+
+  'business-logic': `---
+type: business-logic
+---
+
+# ⚙️ Business Logic Template
+
+Use this template for implementing ViewModels, Services, APIs, DTOs, and other business logic with unit tests. No UI work in this task type.
+
+**Title Format**: \`⚙️ <Feature> business logic\`
+
+**Examples**:
+- ⚙️ User authentication business logic
+- ⚙️ Payment processing business logic
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 📈 Data Flow Diagrams
+> How does data flow in ASCII/Mermaid?
+
+\`\`\`mermaid
+<!-- REPLACE: Full data flow diagram -->
+\`\`\`
+
+## 📦 Packages
+> What packages need to be installed?
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| <!-- REPLACE --> | <!-- REPLACE --> | <!-- REPLACE --> |
+
+---
+
+## 🧠 ViewModels
+> What ViewModels need to be created and/or updated?
+
+### <!-- REPLACE: ViewName -->ViewModel
+
+**Purpose:** <!-- REPLACE: What state and logic does this ViewModel manage? -->
+
+#### State
+- [ ] \`<!-- REPLACE: stateName -->\`: <!-- REPLACE: type --> - <!-- REPLACE: description -->
+
+#### Public Getters
+- [ ] \`<!-- REPLACE: getterName -->\`: <!-- REPLACE: return type --> - <!-- REPLACE: description -->
+
+#### Public Mutators
+- [ ] \`<!-- REPLACE: methodName -->\`: <!-- REPLACE: parameters --> → <!-- REPLACE: return type --> - <!-- REPLACE: description -->
+
+#### On Init
+- [ ] <!-- REPLACE: Initialization step -->
+
+#### On Dispose
+- [ ] <!-- REPLACE: Cleanup step -->
+
+#### TDD Gherkin Tests
+- [ ] \`Given <!-- REPLACE --> When <!-- REPLACE --> Then <!-- REPLACE -->\`
+
+#### View ↔ ViewModel Flow
+\`\`\`mermaid
+sequenceDiagram
+    participant V as View
+    participant VM as ViewModel
+    participant S as Service
+
+    V->>VM: <!-- REPLACE: Action -->
+    VM->>S: <!-- REPLACE: Call -->
+    S-->>VM: <!-- REPLACE: Response -->
+    VM-->>V: <!-- REPLACE: Update -->
+\`\`\`
+
+---
+
+## ⚙️ Services
+> What Services need to be created and/or updated?
+
+### <!-- REPLACE: ServiceName -->Service
+
+**Purpose:** <!-- REPLACE: What business logic does this service handle? -->
+
+#### State
+- [ ] \`<!-- REPLACE: stateName -->\`: <!-- REPLACE: type --> - <!-- REPLACE: description -->
+
+#### Public Getters
+- [ ] \`<!-- REPLACE: getterName -->\`: <!-- REPLACE: return type --> - <!-- REPLACE: description -->
+
+#### Public Mutators
+- [ ] \`<!-- REPLACE: methodName -->\`: <!-- REPLACE: parameters --> → <!-- REPLACE: return type --> - <!-- REPLACE: description -->
+
+#### On Init
+- [ ] <!-- REPLACE: Initialization step -->
+
+#### On Dispose
+- [ ] <!-- REPLACE: Cleanup step -->
+
+#### TDD Gherkin Tests
+- [ ] \`Given <!-- REPLACE --> When <!-- REPLACE --> Then <!-- REPLACE -->\`
+
+#### ViewModel → Service Flow
+\`\`\`mermaid
+sequenceDiagram
+    participant VM as ViewModel
+    participant S as Service
+    participant API as API
+
+    VM->>S: <!-- REPLACE: Call -->
+    S->>API: <!-- REPLACE: Request -->
+    API-->>S: <!-- REPLACE: Response -->
+    S-->>VM: <!-- REPLACE: Result -->
+\`\`\`
+
+---
+
+## 🌐 APIs
+> What APIs need to be created and/or updated?
+
+### <!-- REPLACE: ApiName -->Api
+
+**Purpose:** <!-- REPLACE: What external endpoints does this API wrap? -->
+
+#### Methods
+- [ ] \`<!-- REPLACE: methodName -->\`: <!-- REPLACE: parameters --> → <!-- REPLACE: return type --> - <!-- REPLACE: description -->
+
+---
+
+## 📦 DTOs
+> What DTOs need to be created and/or updated?
+
+### <!-- REPLACE: DtoName -->Dto
+
+\`\`\`yaml
+name: <!-- REPLACE: DtoName -->Dto
+description: <!-- REPLACE: Short description of the DTO -->
+locations:
+  - <!-- REPLACE: Collections where dto is used -->
+fields:
+  <!-- REPLACE: fieldName -->:
+    description: <!-- REPLACE: Description of the field -->
+    type: <!-- REPLACE: string,number,boolean,map,array,null,timestamp,geopoint,reference -->
+    required: <!-- REPLACE: true, false, or condition -->
+    nullable: <!-- REPLACE: true or false -->
+    default: <!-- REPLACE: Default value -->
+    example: <!-- REPLACE: Example value -->
+\`\`\`
+
+---
+
+## 🏷️ Enums
+> What enums need to be created and/or updated?
+
+- [ ] **<!-- REPLACE: EnumName -->**
+    - [ ] \`<!-- REPLACE: enumValue1 -->\`
+    - [ ] \`<!-- REPLACE: enumValue2 -->\`
+
+---
+
+## 📌 Constants
+> What constants are needed?
+
+- [ ] **<!-- REPLACE: ConstantFamily -->**
+    - [ ] \`<!-- REPLACE: CONSTANT_NAME -->\` = \`<!-- REPLACE: value -->\`
+
+---
+
+## 🌍 ARBs (Localization)
+> What localized strings are needed?
+
+| Key | EN | NL |
+|-----|----|----|
+| <!-- REPLACE --> | <!-- REPLACE --> | <!-- REPLACE --> |
+
+---
+
+## 🛠️ Utils
+> What utility classes are needed?
+
+- [ ] **<!-- REPLACE: UtilClassName -->** - <!-- REPLACE: Purpose -->
+    - [ ] \`<!-- REPLACE: methodName -->\`: <!-- REPLACE: description -->
+
+---
+
+## 🧪 TDD Gherkin Unit Tests
+> What cases verify our end goal is reached?
+
+### <!-- REPLACE: TestSuiteName -->
+
+- [ ] \`Given <!-- REPLACE --> When <!-- REPLACE --> Then <!-- REPLACE -->\`
+- [ ] \`Given <!-- REPLACE --> When <!-- REPLACE --> Then <!-- REPLACE -->\`
+`,
+
+  components: `---
+type: components
+---
+
+# 🧩 Components Template
+
+Use this template for creating UI components/widgets and views in isolation. Components should be stateless with primitive parameters.
+
+**Title Format**: \`🧩 <Feature> UI components\`
+
+**Examples**:
+- 🧩 User profile UI components
+- 🧩 Checkout flow UI components
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 🗺️ User Journey
+> What do the complete sequences look like with mermaid diagrams?
+
+### <!-- REPLACE: Scenario Name --> {Actor} is able to [outcome/state achieved]
+
+1. 👤 User [verb] ...
+2. 🧠 System [verb] ...
+3. 🎨 Screen [verb] ...
+
+\`\`\`mermaid
+sequenceDiagram
+    participant U as User
+    participant S as System
+    participant UI as Screen
+
+    U->>UI: <!-- REPLACE: Action -->
+    UI->>S: <!-- REPLACE: Request -->
+    S-->>UI: <!-- REPLACE: Response -->
+    UI-->>U: <!-- REPLACE: Feedback -->
+\`\`\`
+
+---
+
+## 🧩 Components/Widgets
+> What components/widgets need to be created and how do they look?
+
+### <!-- REPLACE: ComponentName -->
+
+**Purpose:** <!-- REPLACE: What this component does -->
+
+**Props/Parameters:**
+- \`<!-- REPLACE: propName -->\`: <!-- REPLACE: type --> - <!-- REPLACE: description -->
+
+**ASCII Representation:**
+\`\`\`
+┌─────────────────────────────────────────┐
+│                                         │
+│  <!-- REPLACE: ASCII mockup -->         │
+│                                         │
+└─────────────────────────────────────────┘
+\`\`\`
+
+**States:**
+- Default: <!-- REPLACE: Description -->
+- Hover: <!-- REPLACE: Description -->
+- Active: <!-- REPLACE: Description -->
+- Disabled: <!-- REPLACE: Description -->
+- Error: <!-- REPLACE: Description -->
+
+---
+
+## 🎨 Views
+> What views/pages need to be created and how do they look?
+
+### <!-- REPLACE: ViewName -->View
+
+**Purpose:** <!-- REPLACE: What this view displays -->
+
+**Route:** <!-- REPLACE: /path/to/view -->
+
+**ASCII Representation:**
+\`\`\`
+┌─────────────────────────────────────────────────────────────┐
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Header                                                  │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                             │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │                                                         │ │
+│ │  <!-- REPLACE: Main content area ASCII mockup -->       │ │
+│ │                                                         │ │
+│ └─────────────────────────────────────────────────────────┘ │
+│                                                             │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Footer                                                  │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+\`\`\`
+
+**View States:**
+- Loading: <!-- REPLACE: Description -->
+- Empty: <!-- REPLACE: Description -->
+- Error: <!-- REPLACE: Description -->
+- Success: <!-- REPLACE: Description -->
+
+**Components Used:**
+- <!-- REPLACE: ComponentName -->
+- <!-- REPLACE: ComponentName -->
+
+---
+
+## 🎨 Design Tokens
+> What (existing) project design tokens are used, created, or updated?
+
+\`\`\`json
+<!-- REPLACE: design tokens used, created and/or updated -->
+\`\`\`
+
+---
+
+## 📋 Storybook/Widgetbook
+> Add components to the project's component showcase page
+
+- [ ] Add <!-- REPLACE: ComponentName --> to Storybook/Widgetbook
+- [ ] Document all component states and variants
+- [ ] Ensure primitive parameters only (no custom objects)
+`,
+
+  research: `---
+type: research
+---
+
+# 🔬 Research Template
+
+Use this template for investigating best practices, evaluating packages, and documenting API usage.
+
+**Title Format**: \`🔬 Investigate <unknown>\`
+
+**Examples**:
+- 🔬 Investigate rate-limiting strategies for API
+- 🔬 Research alternatives to Redis
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 🔍 Best Practices Research
+> What industry standards, patterns, and best practices apply?
+
+### Industry Standards
+\`\`\`text
+<!-- REPLACE: Relevant standards and conventions -->
+\`\`\`
+
+### Recommended Patterns
+\`\`\`text
+<!-- REPLACE: Design patterns, architectural patterns recommended -->
+\`\`\`
+
+### Key Principles
+\`\`\`text
+<!-- REPLACE: Guiding principles for implementation -->
+\`\`\`
+
+## 📦 Package Recommendations
+> What packages have been evaluated and what are the recommendations?
+
+### Recommended Package(s)
+| Package | Version | Pros | Cons | Recommendation |
+|---------|---------|------|------|----------------|
+| <!-- REPLACE --> | <!-- REPLACE --> | <!-- REPLACE --> | <!-- REPLACE --> | Primary/Alternative/Avoid |
+
+### Package Comparison
+\`\`\`text
+<!-- REPLACE: Detailed comparison if multiple options evaluated -->
+\`\`\`
+
+### Final Recommendation
+\`\`\`text
+<!-- REPLACE: Which package(s) to use and why -->
+\`\`\`
+
+## 🌐 API Documentation
+> What external APIs are needed and how do they work?
+
+### API: <!-- REPLACE: API Name -->
+| Property | Value |
+|----------|-------|
+| Base URL | <!-- REPLACE --> |
+| Auth Method | <!-- REPLACE --> |
+| Rate Limits | <!-- REPLACE --> |
+
+#### Key Endpoints
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| <!-- REPLACE --> | <!-- REPLACE --> | <!-- REPLACE --> |
+
+#### Request/Response Examples
+\`\`\`json
+// Request
+<!-- REPLACE: Example request -->
+
+// Response
+<!-- REPLACE: Example response -->
+\`\`\`
+
+## 📖 Reference Implementations
+> What examples, repos, or tutorials provide guidance?
+
+### Code Examples
+| Source | URL | Relevance |
+|--------|-----|-----------|
+| <!-- REPLACE --> | <!-- REPLACE --> | <!-- REPLACE --> |
+
+### Key Learnings
+\`\`\`text
+<!-- REPLACE: Important takeaways from reference implementations -->
+\`\`\`
+
+## ⚠️ Known Limitations/Gotchas
+> What pitfalls, edge cases, or limitations should be avoided?
+
+### Common Pitfalls
+- [ ] <!-- REPLACE: Pitfall description --> - <!-- REPLACE: How to avoid -->
+
+### Edge Cases
+- [ ] <!-- REPLACE: Edge case --> - <!-- REPLACE: How to handle -->
+
+### Performance Considerations
+\`\`\`text
+<!-- REPLACE: Performance-related concerns and mitigations -->
+\`\`\`
+
+### Security Considerations
+\`\`\`text
+<!-- REPLACE: Security-related concerns and mitigations -->
+\`\`\`
+
+## 📋 Deliverables
+> What outputs does this research produce?
+
+- [ ] Package recommendation with rationale
+- [ ] API integration guide
+- [ ] Best practices document
+- [ ] <!-- REPLACE: Other deliverables -->
+`,
+
+  discovery: `---
+type: discovery
+---
+
+# 💡 Discovery Template
+
+Use this template for exploring ideas, validating problems, and assessing business value before committing to implementation.
+
+**Title Format**: \`💡 Explore <idea>\`
+
+**Examples**:
+- 💡 Explore real-time collaboration feature
+- 💡 Explore AI-powered search capabilities
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 💡 Idea
+> What is the core idea in one sentence?
+
+\`\`\`text
+<!-- REPLACE: One sentence summary -->
+\`\`\`
+
+## 🎯 Problem Statement
+> What problem does this solve? Who has this problem?
+
+\`\`\`text
+<!-- REPLACE: Problem and affected users -->
+\`\`\`
+
+## 💰 Business Value & ROI
+> Why does this matter? What's the potential impact?
+
+### Value Score Summary
+**Overall Priority**: 🔴 Low / 🟡 Medium / 🟢 High / 🔥 Critical
+**Estimated ROI Timeline**: <!-- REPLACE: When do we expect returns? -->
+**Investment Required**: <!-- REPLACE: Rough estimate of effort/cost -->
+
+### Impact Assessment
+
+| Dimension | Impact | Justification | Target |
+|-----------|--------|---------------|--------|
+| 💵 Revenue | 🔴/🟡/🟢/🔥 | <!-- REPLACE --> | <!-- REPLACE --> |
+| 📈 User Growth | 🔴/🟡/🟢/🔥 | <!-- REPLACE --> | <!-- REPLACE --> |
+| ⚡ Efficiency | 🔴/🟡/🟢/🔥 | <!-- REPLACE --> | <!-- REPLACE --> |
+| 🎯 Strategic | 🔴/🟡/🟢/🔥 | <!-- REPLACE --> | <!-- REPLACE --> |
+| 🏆 Competitive | 🔴/🟡/🟢/🔥 | <!-- REPLACE --> | <!-- REPLACE --> |
+| 😊 Satisfaction | 🔴/🟡/🟢/🔥 | <!-- REPLACE --> | <!-- REPLACE --> |
+| 🔧 Tech Health | 🔴/🟡/🟢/🔥 | <!-- REPLACE --> | <!-- REPLACE --> |
+
+## 👥 Target Audience
+> Who would benefit most from this?
+
+- Primary: <!-- REPLACE: Main beneficiary -->
+- Secondary: <!-- REPLACE: Other beneficiaries -->
+
+## 🔍 Discovery Paths
+> What do we need to explore or validate before committing?
+
+### Technical Discovery
+- [ ] <!-- REPLACE: Technical feasibility question -->
+- [ ] <!-- REPLACE: Integration/dependency question -->
+
+### User Discovery
+- [ ] <!-- REPLACE: User research question -->
+- [ ] <!-- REPLACE: Usability concern -->
+
+### Business Discovery
+- [ ] <!-- REPLACE: Market/competitive question -->
+- [ ] <!-- REPLACE: Resource/timeline question -->
+
+## 🤔 Open Questions
+> What unknowns need answers?
+
+- [ ] <!-- REPLACE: Critical unknown -->
+
+## 💭 Initial Thoughts
+> Early ideas on how this might work (non-binding brainstorm)
+
+\`\`\`text
+<!-- REPLACE: Initial ideas -->
+\`\`\`
+
+## 🚦 Risks & Concerns
+> What could go wrong or make this difficult?
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| <!-- REPLACE --> | 🔴/🟡/🟢 | 🔴/🟡/🟢 | <!-- REPLACE --> |
+
+## 📊 Success Metrics
+> How would we measure if this succeeds?
+
+- [ ] <!-- REPLACE: Metric 1 -->
+- [ ] <!-- REPLACE: Metric 2 -->
+
+## 🔗 Related Work
+> Links to related tickets, docs, or prior art
+
+- <!-- REPLACE: Related item -->
+
+## 📋 Recommended Next Steps
+> What should happen next to move this forward?
+
+- [ ] <!-- REPLACE: Immediate next action -->
+- [ ] <!-- REPLACE: Follow-up actions -->
+`,
+
+  chore: `---
+type: chore
+---
+
+# 🧹 Chore Template
+
+Use this template for maintenance tasks, cleanup, and housekeeping work.
+
+**Title Format**: \`🧹 <Verb> <thing>\`
+
+**Examples**:
+- 🧹 Update dependencies to latest versions
+- 🧹 Remove unused feature flags
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 🧹 Maintenance Area
+> What part of the system needs attention?
+
+<!-- REPLACE: Specify the area needing maintenance -->
+
+## 📍 Current State
+> What needs cleaning, updating, or removing?
+
+<!-- REPLACE: Describe the current state -->
+
+## 🎯 Target State
+> What should exist after this chore is complete?
+
+<!-- REPLACE: Describe the desired state -->
+
+## 💡 Justification
+> Why is this maintenance needed now?
+
+<!-- REPLACE: Provide reasons for the maintenance task -->
+
+## ✅ Completion Criteria
+> How do we verify the chore is done?
+
+- [ ] <!-- REPLACE: Criterion 1 -->
+- [ ] <!-- REPLACE: Criterion 2 -->
+
+## 🚧 Constraints
+> Any limitations or things to avoid?
+
+- [ ] <!-- REPLACE: Constraint 1 -->
+- [ ] <!-- REPLACE: Constraint 2 -->
+
+## 📝 Notes
+> Additional context if needed
+
+<!-- REPLACE: Any additional notes -->
+`,
+
+  refactor: `---
+type: refactor
+---
+
+# 🧱 Refactor Template
+
+Use this template for code restructuring without changing behavior.
+
+**Title Format**: \`🧱 Refactor <component> to <goal>\`
+
+**Examples**:
+- 🧱 Refactor auth service to remove duplication
+- 🧱 Simplify payment validation logic
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 🎯 Refactoring Goal
+> What technical improvement are we making?
+
+<!-- REPLACE: Clear statement of the refactoring goal -->
+
+## 📍 Current State
+> What is the current code structure?
+
+\`\`\`text
+<!-- REPLACE: Description of current structure, possibly with file paths -->
+\`\`\`
+
+## 🎯 Target State
+> What should the code structure look like after refactoring?
+
+\`\`\`text
+<!-- REPLACE: Description of target structure -->
+\`\`\`
+
+## 💡 Justification
+> Why is this refactoring needed?
+
+- [ ] <!-- REPLACE: Reason 1 (e.g., reduce duplication) -->
+- [ ] <!-- REPLACE: Reason 2 (e.g., improve testability) -->
+
+## 🚫 Behavior Changes
+> Confirm: NO behavior changes
+
+- [ ] This refactoring does NOT change any external behavior
+- [ ] All existing tests should pass without modification
+- [ ] No API/interface changes that affect consumers
+
+## 📋 Refactoring Steps
+> What steps will be taken?
+
+1. [ ] <!-- REPLACE: Step 1 -->
+2. [ ] <!-- REPLACE: Step 2 -->
+3. [ ] <!-- REPLACE: Step 3 -->
+
+## ✅ Completion Criteria
+> How do we verify the refactoring is successful?
+
+- [ ] All existing tests pass
+- [ ] No behavior changes detected
+- [ ] Code structure matches target state
+- [ ] <!-- REPLACE: Additional criteria -->
+
+## 🚧 Constraints
+> Any limitations or things to avoid?
+
+- [ ] Do not change public APIs
+- [ ] <!-- REPLACE: Other constraints -->
+
+## 📝 Notes
+> Additional context if needed
+
+<!-- REPLACE: Any additional notes -->
+`,
+
+  infrastructure: `---
+type: infrastructure
+---
+
+# 🏗️ Infrastructure Template
+
+Use this template for CI/CD, deployment, hosting, and DevOps work.
+
+**Title Format**: \`🏗️ Set up <infrastructure>\`
+
+**Examples**:
+- 🏗️ Set up GitHub Actions CI pipeline
+- 🏗️ Configure Docker deployment
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 🎯 Infrastructure Goal
+> What infrastructure capability are we adding or improving?
+
+<!-- REPLACE: Clear statement of the infrastructure goal -->
+
+## 📍 Current State
+> What is the current infrastructure setup?
+
+<!-- REPLACE: Description of current infrastructure -->
+
+## 🎯 Target State
+> What should the infrastructure look like after this work?
+
+<!-- REPLACE: Description of target infrastructure -->
+
+## 🔧 Components
+> What infrastructure components are involved?
+
+### CI/CD
+- [ ] <!-- REPLACE: Pipeline configuration -->
+- [ ] <!-- REPLACE: Build steps -->
+- [ ] <!-- REPLACE: Test automation -->
+
+### Deployment
+- [ ] <!-- REPLACE: Deployment target -->
+- [ ] <!-- REPLACE: Deployment strategy -->
+- [ ] <!-- REPLACE: Rollback plan -->
+
+### Hosting
+- [ ] <!-- REPLACE: Hosting provider -->
+- [ ] <!-- REPLACE: Configuration -->
+- [ ] <!-- REPLACE: Scaling strategy -->
+
+### Monitoring
+- [ ] <!-- REPLACE: Logging -->
+- [ ] <!-- REPLACE: Alerting -->
+- [ ] <!-- REPLACE: Metrics -->
+
+## 🔐 Security Considerations
+> What security measures are needed?
+
+- [ ] <!-- REPLACE: Secret management -->
+- [ ] <!-- REPLACE: Access control -->
+- [ ] <!-- REPLACE: Network security -->
+
+## 📋 Configuration Files
+> What configuration files will be created/modified?
+
+| File | Purpose |
+|------|---------|
+| <!-- REPLACE --> | <!-- REPLACE --> |
+
+## ✅ Completion Criteria
+> How do we verify the infrastructure is working?
+
+- [ ] Pipeline runs successfully
+- [ ] Deployment completes without errors
+- [ ] Monitoring is active
+- [ ] <!-- REPLACE: Additional criteria -->
+
+## 🚧 Constraints
+> Any limitations or things to avoid?
+
+- [ ] <!-- REPLACE: Cost constraints -->
+- [ ] <!-- REPLACE: Technology constraints -->
+
+## 📝 Notes
+> Additional context if needed
+
+<!-- REPLACE: Any additional notes -->
+`,
+
+  documentation: `---
+type: documentation
+---
+
+# 📄 Documentation Template
+
+Use this template for creating or updating READMEs, architecture docs, and API documentation.
+
+**Title Format**: \`📄 Document <thing>\`
+
+**Examples**:
+- 📄 Document authentication API endpoints
+- 📄 Update README with setup instructions
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 🎯 Documentation Goal
+> What documentation are we creating or updating?
+
+<!-- REPLACE: Clear statement of the documentation goal -->
+
+## 📍 Current State
+> What documentation exists currently?
+
+<!-- REPLACE: Description of current documentation state -->
+
+## 🎯 Target State
+> What should the documentation look like after this work?
+
+<!-- REPLACE: Description of target documentation -->
+
+## 📚 Documentation Type
+> What type of documentation is this?
+
+- [ ] README
+- [ ] Architecture documentation
+- [ ] API documentation
+- [ ] User guide
+- [ ] Developer guide
+- [ ] Changelog
+- [ ] Other: <!-- REPLACE -->
+
+## 📋 Sections to Create/Update
+> What sections need to be written?
+
+### New Sections
+- [ ] <!-- REPLACE: Section name --> - <!-- REPLACE: Brief description -->
+
+### Sections to Update
+- [ ] <!-- REPLACE: Section name --> - <!-- REPLACE: What changes -->
+
+## 👥 Target Audience
+> Who will read this documentation?
+
+- Primary: <!-- REPLACE: Main audience -->
+- Secondary: <!-- REPLACE: Other readers -->
+
+## 📝 Content Outline
+> What content will be included?
+
+\`\`\`markdown
+# <!-- REPLACE: Document title -->
+
+## <!-- REPLACE: Section 1 -->
+<!-- REPLACE: Brief description of content -->
+
+## <!-- REPLACE: Section 2 -->
+<!-- REPLACE: Brief description of content -->
+\`\`\`
+
+## ✅ Completion Criteria
+> How do we verify the documentation is complete?
+
+- [ ] All planned sections are written
+- [ ] Code examples are tested and working
+- [ ] Links are valid
+- [ ] Spelling and grammar checked
+- [ ] <!-- REPLACE: Additional criteria -->
+
+## 🚧 Constraints
+> Any limitations or guidelines to follow?
+
+- [ ] Follow existing documentation style
+- [ ] <!-- REPLACE: Other constraints -->
+
+## 📝 Notes
+> Additional context if needed
+
+<!-- REPLACE: Any additional notes -->
+`,
+
+  release: `---
+type: release
+---
+
+# 🚀 Release Template
+
+Use this template for version bumping, changelog updates, and release preparation.
+
+**Title Format**: \`🚀 Prepare release v<version>\`
+
+**Examples**:
+- 🚀 Prepare release v2.0.0
+- 🚀 Prepare release v1.5.3
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: Task IDs that block this work -->
+
+## 📦 Release Information
+
+### Version
+- **Current Version**: <!-- REPLACE: Current version -->
+- **New Version**: <!-- REPLACE: New version -->
+- **Release Type**: Major / Minor / Patch
+
+### Release Date
+- **Target Date**: <!-- REPLACE: Target release date -->
+
+## 📋 Release Checklist
+
+### Pre-Release
+- [ ] All planned features are complete
+- [ ] All tests pass
+- [ ] No critical bugs outstanding
+- [ ] Documentation is up to date
+- [ ] CHANGELOG is updated
+
+### Version Bump
+- [ ] Update version in package.json / pubspec.yaml / etc.
+- [ ] Update version constants in code (if any)
+- [ ] Update version references in documentation
+
+### Changelog
+- [ ] Add new version section to CHANGELOG.md
+- [ ] List all notable changes since last release
+- [ ] Categorize changes (Added, Changed, Fixed, Removed)
+- [ ] Include links to relevant PRs/issues
+
+### Build & Test
+- [ ] Run full test suite
+- [ ] Build production artifacts
+- [ ] Test production build locally
+
+### Release
+- [ ] Create git tag
+- [ ] Push tag to remote
+- [ ] Create GitHub release (if applicable)
+- [ ] Publish to package registry (npm, pub.dev, etc.)
+
+### Post-Release
+- [ ] Verify package is available
+- [ ] Update any dependent projects
+- [ ] Announce release (if applicable)
+
+## 📝 Changelog Draft
+
+\`\`\`markdown
+## [<!-- REPLACE: version -->] - <!-- REPLACE: date -->
+
+### Added
+- <!-- REPLACE: New features -->
+
+### Changed
+- <!-- REPLACE: Changes to existing features -->
+
+### Fixed
+- <!-- REPLACE: Bug fixes -->
+
+### Removed
+- <!-- REPLACE: Removed features -->
+\`\`\`
+
+## 🚨 Breaking Changes
+> List any breaking changes that require user action
+
+- [ ] <!-- REPLACE: Breaking change --> - Migration: <!-- REPLACE: How to migrate -->
+
+## ✅ Completion Criteria
+> How do we verify the release is successful?
+
+- [ ] New version is published and installable
+- [ ] Changelog accurately reflects changes
+- [ ] No regressions in functionality
+- [ ] <!-- REPLACE: Additional criteria -->
+
+## 📝 Notes
+> Additional context if needed
+
+<!-- REPLACE: Any additional notes -->
+`,
+
+  implementation: `---
+type: implementation
+---
+
+# 🔧 Implementation Template
+
+Use this template for wiring components to business logic and integration work. Assumes components are created and business logic is tested.
+
+**Title Format**: \`🔧 Wire <feature> to business logic\`
+
+**Examples**:
+- 🔧 Wire user profile to ProfileViewModel
+- 🔧 Wire checkout flow to PaymentService
+
+---
+
+## 🔗 Dependencies
+> Which tasks need to be completed first (if any)?
+
+- [ ] <!-- REPLACE: components task ID -->
+- [ ] <!-- REPLACE: business-logic task ID -->
+
+## 🎯 End Goal
+> What is the tangible outcome of this integration?
+
+<!-- REPLACE: Clear description of what will work end-to-end after this task -->
+
+## 📍 Currently
+> What is the current state?
+
+- Components exist but are not connected to data
+- Business logic is tested but not wired to UI
+- <!-- REPLACE: Other current state items -->
+
+## 🎯 Should
+> What should the state be after implementation?
+
+- Components receive real data from ViewModels/Services
+- User actions trigger business logic
+- Data flows end-to-end from UI to backend
+- <!-- REPLACE: Other expected outcomes -->
+
+## 🔌 Integration Points
+> What needs to be connected?
+
+### View ↔ ViewModel Connections
+
+| View | ViewModel | Connection |
+|------|-----------|------------|
+| <!-- REPLACE: ViewName --> | <!-- REPLACE: ViewModelName --> | <!-- REPLACE: What data/actions --> |
+
+### Component ↔ State Connections
+
+| Component | State Source | Data Flow |
+|-----------|--------------|-----------|
+| <!-- REPLACE: ComponentName --> | <!-- REPLACE: ViewModel/Service --> | <!-- REPLACE: What data --> |
+
+## 📈 Data Flow
+> How does data flow through the integrated system?
+
+\`\`\`mermaid
+sequenceDiagram
+    participant U as User
+    participant V as View
+    participant VM as ViewModel
+    participant S as Service
+    participant API as API
+
+    U->>V: <!-- REPLACE: User action -->
+    V->>VM: <!-- REPLACE: Call method -->
+    VM->>S: <!-- REPLACE: Business logic -->
+    S->>API: <!-- REPLACE: API call -->
+    API-->>S: <!-- REPLACE: Response -->
+    S-->>VM: <!-- REPLACE: Update state -->
+    VM-->>V: <!-- REPLACE: Notify -->
+    V-->>U: <!-- REPLACE: Display result -->
+\`\`\`
+
+## ✅ Acceptance Criteria
+> How do we verify the integration works?
+
+- [ ] User can <!-- REPLACE: Complete user action -->
+- [ ] Data persists correctly
+- [ ] Error states are handled
+- [ ] Loading states display correctly
+
+## ⚠️ Constraints
+> What limitations or constraints exist?
+
+- [ ] <!-- REPLACE: Constraint 1 -->
+
+## 🧪 Integration Tests
+> What integration tests verify the wiring?
+
+- [ ] \`Given <!-- REPLACE --> When <!-- REPLACE --> Then <!-- REPLACE -->\`
+
+## 📝 Notes
+> Additional context for integration
+
+<!-- REPLACE: Any gotchas, edge cases, or special considerations -->
+`,
+};
+
+/**
+ * Discovers task templates from the workspace/templates/ directory.
+ * Returns user-defined templates with their type and content.
+ */
+export async function discoverTemplates(workspacePath: string): Promise<TemplateInfo[]> {
+  const templatesDir = path.join(workspacePath, 'templates');
+  const templates: TemplateInfo[] = [];
+
+  try {
+    // Check if templates directory exists
+    await fs.access(templatesDir);
+  } catch {
+    // Directory doesn't exist, return empty array
+    return templates;
+  }
+
+  try {
+    const entries = await fs.readdir(templatesDir);
+    const markdownFiles = entries.filter((f) => f.endsWith('.md'));
+
+    for (const filename of markdownFiles) {
+      const filePath = path.join(templatesDir, filename);
+
+      try {
+        // Check if it's a file (not directory)
+        const stat = await fs.stat(filePath);
+        if (!stat.isFile()) continue;
+
+        // Read file content
+        const content = await fs.readFile(filePath, 'utf-8');
+
+        // Extract frontmatter to get the type
+        // We need to parse the YAML frontmatter manually since MarkdownParser
+        // doesn't store all fields in the raw object
+        const lines = content.split('\n');
+        if (lines.length === 0 || lines[0].trim() !== '---') {
+          continue;
+        }
+
+        let endIndex = -1;
+        for (let i = 1; i < lines.length; i++) {
+          if (lines[i].trim() === '---') {
+            endIndex = i;
+            break;
+          }
+        }
+
+        if (endIndex === -1) {
+          continue;
+        }
+
+        const yamlLines = lines.slice(1, endIndex);
+        let type: string | null = null;
+
+        // Parse type field from YAML
+        for (const line of yamlLines) {
+          const match = line.match(/^type\s*:\s*(.+)$/);
+          if (match) {
+            type = match[1].trim().replace(/^["']|["']$/g, '');
+            break;
+          }
+        }
+
+        // Skip files without valid type in frontmatter
+        if (!type) {
+          continue;
+        }
+
+        templates.push({
+          type,
+          content,
+          source: 'user',
+          filePath,
+        });
+      } catch {
+        // Skip files that can't be read
+        continue;
+      }
+    }
+  } catch {
+    // Error reading directory, return what we have
+    return templates;
+  }
+
+  return templates;
+}
+
+/**
+ * Returns all built-in templates.
+ */
+export function getBuiltInTemplates(): TemplateInfo[] {
+  return Object.entries(BUILT_IN_TEMPLATES).map(([type, content]) => ({
+    type,
+    content,
+    source: 'built-in' as const,
+  }));
+}
+
+/**
+ * Returns all available template types, with user templates overriding built-in templates.
+ */
+export async function getAvailableTypes(workspacePath: string): Promise<TemplateInfo[]> {
+  const userTemplates = await discoverTemplates(workspacePath);
+  const builtInTemplates = getBuiltInTemplates();
+
+  // Create a map to handle overrides (user templates override built-in)
+  const templateMap = new Map<string, TemplateInfo>();
+
+  // Add built-in templates first
+  for (const template of builtInTemplates) {
+    templateMap.set(template.type, template);
+  }
+
+  // Override with user templates
+  for (const template of userTemplates) {
+    templateMap.set(template.type, template);
+  }
+
+  return Array.from(templateMap.values());
+}
+
+/**
+ * Returns the template content for a specific type.
+ * Checks user templates first, then falls back to built-in templates.
+ * Returns null if the type is not found.
+ */
+export async function getTemplateByType(
+  type: string,
+  workspacePath: string
+): Promise<string | null> {
+  // Check user templates first
+  const userTemplates = await discoverTemplates(workspacePath);
+  const userTemplate = userTemplates.find((t) => t.type === type);
+  if (userTemplate) {
+    return userTemplate.content;
+  }
+
+  // Fall back to built-in templates
+  const builtInTemplate = BUILT_IN_TEMPLATES[type];
+  if (builtInTemplate) {
+    return builtInTemplate;
+  }
+
+  // Type not found
+  return null;
+}

--- a/src/core/validation/constants.ts
+++ b/src/core/validation/constants.ts
@@ -37,6 +37,8 @@ export const VALIDATION_MESSAGES = {
   DELTA_MISSING_REQUIREMENTS: 'Delta should include requirements',
   TASK_MISSING_SKILL_LEVEL: 'Task is missing skill-level field (values: junior, medior, senior)',
   TASK_INVALID_SKILL_LEVEL: 'Task has invalid skill-level value (must be junior, medior, or senior)',
+  TASK_MISSING_TYPE: 'Task has no type specified',
+  TASK_UNKNOWN_TYPE: 'Unknown task type',
 
   // Guidance snippets (appended to primary messages for remediation)
   GUIDE_NO_DELTAS:

--- a/src/utils/centralized-task-discovery.ts
+++ b/src/utils/centralized-task-discovery.ts
@@ -14,6 +14,8 @@ import {
   parseTaskParentInfo,
   parseStatus,
   parseSkillLevel,
+  parseType,
+  parseBlockedBy,
   completeImplementationChecklist,
   TaskStatus,
   SkillLevel,
@@ -29,6 +31,8 @@ export interface DiscoveredTask {
   skillLevel?: SkillLevel;
   parentType?: ParentType;
   parentId?: string;
+  type?: string;
+  blockedBy?: string[];
 }
 
 export interface TaskDiscoveryResult {
@@ -115,6 +119,10 @@ export async function discoverTasks(
           continue;
         }
 
+        // Parse optional type and blocked-by fields
+        const type = parseType(content);
+        const blockedBy = parseBlockedBy(content);
+
         // Parse filename with parent hint
         const parsed = parseTaskFilename(filename, !!parentId);
         if (!parsed) continue;
@@ -129,6 +137,8 @@ export async function discoverTasks(
           skillLevel,
           parentType,
           parentId,
+          type,
+          blockedBy,
         });
       } catch {
         // Skip files that can't be read

--- a/test/core/templates/slash-command-templates.test.ts
+++ b/test/core/templates/slash-command-templates.test.ts
@@ -44,5 +44,13 @@ describe('slash-command-templates', () => {
       expect(typeof result).toBe('string');
       expect(result.length).toBeGreaterThan(0);
     });
+
+    it('plan-proposal includes template reading step', () => {
+      const result = getSlashCommandBody('plan-proposal');
+      expect(result).toContain('Read all task templates in `workspace/templates/`');
+      expect(result).toContain('workspace/AGENTS.md');
+      expect(result).toContain('type: <template-type>');
+      expect(result).toContain('blocked-by:');
+    });
   });
 });

--- a/test/core/templates/template-discovery.test.ts
+++ b/test/core/templates/template-discovery.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  discoverTemplates,
+  getBuiltInTemplates,
+  getAvailableTypes,
+  getTemplateByType,
+} from '../../../src/core/templates/template-discovery.js';
+
+describe('Template Discovery', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    // Create a temporary directory for testing
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'template-test-'));
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('getBuiltInTemplates', () => {
+    it('should return all 12 built-in templates', () => {
+      const templates = getBuiltInTemplates();
+      expect(templates).toHaveLength(12);
+
+      const types = templates.map((t) => t.type);
+      expect(types).toContain('story');
+      expect(types).toContain('bug');
+      expect(types).toContain('business-logic');
+      expect(types).toContain('components');
+      expect(types).toContain('research');
+      expect(types).toContain('discovery');
+      expect(types).toContain('chore');
+      expect(types).toContain('refactor');
+      expect(types).toContain('infrastructure');
+      expect(types).toContain('documentation');
+      expect(types).toContain('release');
+      expect(types).toContain('implementation');
+    });
+
+    it('should return templates with correct structure', () => {
+      const templates = getBuiltInTemplates();
+      for (const template of templates) {
+        expect(template).toHaveProperty('type');
+        expect(template).toHaveProperty('content');
+        expect(template).toHaveProperty('source');
+        expect(template.source).toBe('built-in');
+        expect(template.content).toContain('---');
+        expect(template.content).toContain(`type: ${template.type}`);
+      }
+    });
+  });
+
+  describe('discoverTemplates', () => {
+    it('should return empty array when templates directory does not exist', async () => {
+      const templates = await discoverTemplates(tempDir);
+      expect(templates).toEqual([]);
+    });
+
+    it('should discover user templates from workspace/templates/', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const customTemplate = `---
+type: custom
+---
+
+# Custom Template
+
+This is a custom template for testing.
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'custom.md'), customTemplate);
+
+      const templates = await discoverTemplates(tempDir);
+      expect(templates).toHaveLength(1);
+      expect(templates[0].type).toBe('custom');
+      expect(templates[0].content).toBe(customTemplate);
+      expect(templates[0].source).toBe('user');
+      expect(templates[0].filePath).toBe(path.join(templatesDir, 'custom.md'));
+    });
+
+    it('should skip files without type in frontmatter', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const invalidTemplate = `---
+title: Invalid
+---
+
+# Invalid Template
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'invalid.md'), invalidTemplate);
+
+      const templates = await discoverTemplates(tempDir);
+      expect(templates).toEqual([]);
+    });
+
+    it('should skip files without frontmatter', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const noFrontmatter = `# Template Without Frontmatter
+
+This template has no frontmatter.
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'no-frontmatter.md'), noFrontmatter);
+
+      const templates = await discoverTemplates(tempDir);
+      expect(templates).toEqual([]);
+    });
+
+    it('should skip non-markdown files', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      await fs.writeFile(path.join(templatesDir, 'README.txt'), 'Not a markdown file');
+
+      const templates = await discoverTemplates(tempDir);
+      expect(templates).toEqual([]);
+    });
+
+    it('should discover multiple templates', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const template1 = `---
+type: custom1
+---
+
+# Custom Template 1
+`;
+
+      const template2 = `---
+type: custom2
+---
+
+# Custom Template 2
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'custom1.md'), template1);
+      await fs.writeFile(path.join(templatesDir, 'custom2.md'), template2);
+
+      const templates = await discoverTemplates(tempDir);
+      expect(templates).toHaveLength(2);
+
+      const types = templates.map((t) => t.type);
+      expect(types).toContain('custom1');
+      expect(types).toContain('custom2');
+    });
+  });
+
+  describe('getAvailableTypes', () => {
+    it('should return all built-in templates when no user templates exist', async () => {
+      const templates = await getAvailableTypes(tempDir);
+      expect(templates).toHaveLength(12);
+    });
+
+    it('should include user templates alongside built-in templates', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const customTemplate = `---
+type: custom
+---
+
+# Custom Template
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'custom.md'), customTemplate);
+
+      const templates = await getAvailableTypes(tempDir);
+      expect(templates).toHaveLength(13); // 12 built-in + 1 custom
+
+      const types = templates.map((t) => t.type);
+      expect(types).toContain('custom');
+      expect(types).toContain('story');
+    });
+
+    it('should allow user templates to override built-in templates', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const overrideTemplate = `---
+type: story
+---
+
+# Custom Story Template
+
+This overrides the built-in story template.
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'story.md'), overrideTemplate);
+
+      const templates = await getAvailableTypes(tempDir);
+      expect(templates).toHaveLength(12); // Still 12 templates
+
+      const storyTemplate = templates.find((t) => t.type === 'story');
+      expect(storyTemplate).toBeDefined();
+      expect(storyTemplate!.source).toBe('user');
+      expect(storyTemplate!.content).toContain('This overrides the built-in story template.');
+    });
+  });
+
+  describe('getTemplateByType', () => {
+    it('should return built-in template when no user template exists', async () => {
+      const content = await getTemplateByType('story', tempDir);
+      expect(content).not.toBeNull();
+      expect(content).toContain('# ✨ Story Template');
+      expect(content).toContain('type: story');
+    });
+
+    it('should return user template when it exists', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const customTemplate = `---
+type: custom
+---
+
+# Custom Template Content
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'custom.md'), customTemplate);
+
+      const content = await getTemplateByType('custom', tempDir);
+      expect(content).toBe(customTemplate);
+    });
+
+    it('should prioritize user template over built-in template', async () => {
+      const templatesDir = path.join(tempDir, 'templates');
+      await fs.mkdir(templatesDir, { recursive: true });
+
+      const overrideTemplate = `---
+type: bug
+---
+
+# Custom Bug Template
+
+This is a user-defined bug template.
+`;
+
+      await fs.writeFile(path.join(templatesDir, 'bug.md'), overrideTemplate);
+
+      const content = await getTemplateByType('bug', tempDir);
+      expect(content).toBe(overrideTemplate);
+      expect(content).toContain('This is a user-defined bug template.');
+    });
+
+    it('should return null for non-existent template type', async () => {
+      const content = await getTemplateByType('non-existent', tempDir);
+      expect(content).toBeNull();
+    });
+
+    it('should return correct content for all built-in types', async () => {
+      const builtInTypes = [
+        'story',
+        'bug',
+        'business-logic',
+        'components',
+        'research',
+        'discovery',
+        'chore',
+        'refactor',
+        'infrastructure',
+        'documentation',
+        'release',
+        'implementation',
+      ];
+
+      for (const type of builtInTypes) {
+        const content = await getTemplateByType(type, tempDir);
+        expect(content).not.toBeNull();
+        expect(content).toContain(`type: ${type}`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `--type` option to `plx create task` for categorizing tasks (story, bug, business-logic, components, etc.)
- Adds `--blocked-by` option to `plx create task` for specifying task dependencies
- Adds `--type` and `--blocked-by` filters to `plx get task` and `plx get tasks` commands
- Implements template discovery system to dynamically list available task types from workspace templates
- Updates all slash command configurators with task type and blocked-by option documentation

## Test plan
- [ ] Run `plx create task "Test task" --type story` and verify type is set in the created task file
- [ ] Run `plx create task "Blocked task" --blocked-by task-001,task-002` and verify blocked-by is set
- [ ] Run `plx get tasks --type bug` and verify filtering works
- [ ] Run `plx get task --blocked-by task-001` and verify filtering works
- [ ] Run tests with `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a typed task system with template discovery and dependency tracking, plus CLI, parsing, validation, and slash command updates.
> 
> - **Task types + templates**: New `type:` frontmatter with 12 built-in templates, user overrides via `workspace/templates/`; new discovery APIs (`discoverTemplates`, `getAvailableTypes`, `getTemplateByType`) and `--type` support/validation in `splx create task`
> - **Dependencies (`blocked-by`)**: Frontmatter parsing + CLI `--blocked-by`, shown in `splx get task` output with status checks and warnings; included in JSON responses
> - **CLI get UX**: Task headers/tables show colored type badges/columns; JSON for `get task(s)` now includes `type` and `blockedBy`
> - **Parsing/validation**: Markdown parser reads `type` and `blocked-by`; validator warns on missing type and errors on unknown types (strict), using discovered types
> - **Slash commands**: New `sync-tasks` command added across all configurators; `plan-proposal` template updated to reference templates/types/dependencies
> - **Docs/tests**: AGENTS.md template expanded with task templates/dependencies guidance; CHANGELOG updated; new tests for template discovery, parsing, and validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit def18d7f15794e6fea3b597d8433cf72d3ebdef7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->